### PR TITLE
Make sure emojis are always small on mobile

### DIFF
--- a/event.py
+++ b/event.py
@@ -231,6 +231,8 @@ class Event:
                                      value="\N{ZERO WIDTH SPACE}",
                                      inline=group.isInline)
 
+        eventEmbed.set_footer(text="Event ID: " + str(self.id))
+
         return eventEmbed
 
     # Add default role groups

--- a/messageFunctions.py
+++ b/messageFunctions.py
@@ -46,7 +46,6 @@ async def createEventMessage(event: Event, channel: TextChannel,
     """Create a new event message."""
     # Create embed and message
     embed = event.createEmbed()
-    embed.set_footer(text="Event ID: " + str(event.id))
     message = await channel.send(embed=embed)
     if update_id:
         event.messageID = message.id
@@ -59,7 +58,6 @@ async def updateMessageEmbed(eventMessage: Message, updatedEvent: Event) \
         -> None:
     """Update the embed and footer of a message."""
     newEventEmbed = updatedEvent.createEmbed()
-    newEventEmbed.set_footer(text="Event ID: " + str(updatedEvent.id))
     await eventMessage.edit(embed=newEventEmbed)
 
 

--- a/role.py
+++ b/role.py
@@ -19,7 +19,10 @@ class Role:
                                         self.name,
                                         self.userName)
         else:
-            return "{} {}\n".format(str(self.emoji), self.userName)
+            if self.userName:
+                return f"{str(self.emoji)} {self.userName}\n"
+            else:
+                return f"{str(self.emoji)}\N{ZERO WIDTH SPACE}\n"
 
     def __repr__(self):
         return f"<Role name='{self.name}' userName='{self.userName}'>"


### PR DESCRIPTION
Lone emojis would show as large on mobile, this makes sure there's always
some content next to an emoji.

Before:
![image](https://user-images.githubusercontent.com/636701/117713912-ea7f4f00-b1de-11eb-8d28-333be017e3ae.png)
After:
![image](https://user-images.githubusercontent.com/636701/117713935-f0753000-b1de-11eb-8304-ab3febabe661.png)