### PR TITLE
Move converters into a separate module

### DIFF
--- a/cogs/repl.py
+++ b/cogs/repl.py
@@ -56,7 +56,7 @@ class REPL(commands.Cog):
         to_compile = f"async def func():\n{textwrap.indent(body, '  ')}"
 
         try:
-            exec(to_compile, env)
+            exec(to_compile, env)  # pylint: disable=exec-used
         except SyntaxError as e:
             return await ctx.send(self.get_syntax_error(e))
 
@@ -64,14 +64,14 @@ class REPL(commands.Cog):
         try:
             with redirect_stdout(stdout):
                 ret = await func()
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             value = stdout.getvalue()
             await ctx.send(f'```py\n{value}{traceback.format_exc()}\n```')
         else:
             value = stdout.getvalue()
             try:
                 await ctx.message.add_reaction('\u2705')
-            except Exception:
+            except Exception:  # pylint: disable=broad-except
                 await ctx.send(f'```py\n{traceback.format_exc()}\n```')
 
             if ret is None:
@@ -148,7 +148,7 @@ class REPL(commands.Cog):
                     result = executor(code, variables)
                     if inspect.isawaitable(result):
                         result = await result
-            except Exception:
+            except Exception:  # pylint: disable=broad-except
                 value = stdout.getvalue()
                 fmt = f'```py\n{value}{traceback.format_exc()}\n```'
             else:

--- a/converters.py
+++ b/converters.py
@@ -1,0 +1,90 @@
+from datetime import date, datetime, time
+from typing import cast
+
+from discord import Message
+from discord.ext.commands.context import Context
+from discord.ext.commands.errors import BadArgument
+
+import messageFunctions as msgFnc
+from errors import EventNotFound, MessageNotFound
+from event import Event
+from eventDatabase import EventDatabase
+from operationbot import OperationBot
+
+
+class ArgEvent(Event):
+    @classmethod
+    async def convert(cls, _: Context, arg: str) -> Event:
+        return await cls._convert(arg)
+
+    @classmethod
+    async def _convert(cls, arg: str, archived=False) -> Event:
+        try:
+            event_id = int(arg)
+        except ValueError as e:
+            raise BadArgument(f"Invalid message ID {arg}, needs to be an "
+                              "integer") from e
+
+        try:
+            if not archived:
+                event = EventDatabase.getEventByID(event_id)
+            else:
+                event = EventDatabase.getArchivedEventByID(event_id)
+        except EventNotFound as e:
+            raise BadArgument(str(e)) from e
+
+        return event
+
+
+class ArgArchivedEvent(ArgEvent):
+    @classmethod
+    async def convert(cls, _: Context, arg: str) -> Event:
+        return await cls._convert(arg, archived=True)
+
+
+class ArgDateTime(datetime):
+    @classmethod
+    async def convert(cls, ctx: Context, arg: str) -> datetime:
+        _date = await ArgDate.convert(ctx, arg)
+        return datetime.combine(_date, time(hour=18, minute=30))
+
+
+class ArgDate(date):
+    @classmethod
+    async def convert(cls, _: Context, arg: str) -> date:
+        try:
+            return date.fromisoformat(arg)
+        except ValueError as e:
+            raise BadArgument(f"Invalid date format {arg}. "
+                              "Has to be YYYY-MM-DD") from e
+
+
+class ArgTime(time):
+    @classmethod
+    async def convert(cls, _: Context, arg: str) -> time:
+        for fmt in ('%H:%M', '%H%M'):
+            try:
+                _date = datetime.strptime(arg, fmt)
+                return time(_date.hour, _date.minute)
+            except ValueError:
+                pass
+        raise BadArgument(f"Invalid time format {arg}. "
+                          "Has to be HH:MM or HHMM")
+
+
+class ArgMessage(Message):
+    @classmethod
+    async def convert(cls, ctx: Context, arg: str) -> Message:
+        try:
+            event_id = int(arg)
+        except ValueError as e:
+            raise BadArgument(f"Invalid message ID {arg}, needs to be an "
+                              "integer") from e
+        try:
+            event = EventDatabase.getEventByID(event_id)
+            message = await msgFnc.getEventMessage(
+                event, cast(OperationBot, ctx.bot))
+        except (EventNotFound, MessageNotFound) as e:
+            raise BadArgument(str(e)) from e
+
+        return message

--- a/eventListener.py
+++ b/eventListener.py
@@ -109,12 +109,11 @@ class EventListener(Cog):
         late_signoff_delta = None
         old_role = ""
 
-        """
-        if user is not signed up and the role is free, sign up
-        if user is not signed up and the role is not free, do nothing
-        if user is signed up and they select the same role, sign off
-        if user is signed up and they select a different role, change to that role
-        """  # NOQA
+        # if user is not signed up and the role is free, sign up
+        # if user is not signed up and the role is not free, do nothing
+        # if user is signed up and they select the same role, sign off
+        # if user is signed up and they select a different role,
+        #    change to that role
         if old_signup and emoji == old_signup.emoji:
             # User clicked a reaction of the current signed up role
             removed_role = event.undoSignup(user)

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ if s.VERSION != SECRET_VERSION:
 initial_extensions = ['commandListener', 'eventListener', 'cogs.repl']
 
 intents = discord.Intents.default()
-intents.members = True
+intents.members = True  # pylint: disable=assigning-non-slot
 bot = OperationBot(command_prefix=COMMAND_CHAR, intents=intents)
 # bot.remove_command("help")
 

--- a/messageFunctions.py
+++ b/messageFunctions.py
@@ -6,6 +6,7 @@ from discord.errors import Forbidden
 
 from errors import MessageNotFound, RoleError
 from event import Event
+from eventDatabase import EventDatabase
 from operationbot import OperationBot
 
 
@@ -19,16 +20,15 @@ async def getEventMessage(event: Event, bot: OperationBot, archived=False) \
 
     try:
         return await channel.fetch_message(event.messageID)
-    except NotFound:
+    except NotFound as e:
         raise MessageNotFound("No event message found with "
-                              f"message ID {event.messageID}")
+                              f"message ID {event.messageID}") from e
 
 
 async def sortEventMessages(bot: OperationBot):
     """Sort events in event database.
 
     Raises MessageNotFound if messages are missing."""
-    from eventDatabase import EventDatabase
     EventDatabase.sortEvents()
 
     event: Event
@@ -36,7 +36,7 @@ async def sortEventMessages(bot: OperationBot):
         try:
             message = await getEventMessage(event, bot)
         except MessageNotFound as e:
-            raise MessageNotFound(f"sortEventMessages: {e}")
+            raise MessageNotFound(f"sortEventMessages: {e}") from e
         await updateMessageEmbed(message, event)
         await updateReactions(event, message=message)
 
@@ -118,7 +118,7 @@ async def updateReactions(event: Event, message: Message = None, bot=None,
         except Forbidden as e:
             if e.code == 30010:
                 raise RoleError("Too many reactions, not adding role "
-                                f"{emoji}. This should not happen.")
+                                f"{emoji}. This should not happen.") from e
 
 # async def createMessages(events: Dict[int, Event], bot):
 #     # Update event message contents and add reactions

--- a/reload.py
+++ b/reload.py
@@ -27,7 +27,7 @@ class Reload(Cog):
             try:
                 self.bot.load_extension(extension)
                 print("loaded", extension)
-            except Exception:
+            except Exception:  # pylint: disable=broad-except
                 await ctx.send("An error occured while reloading: "
                                f"```py\n{traceback.format_exc()}```")
             else:

--- a/role.py
+++ b/role.py
@@ -16,11 +16,9 @@ class Role:
         # Add name after emote if it should display
         if self.show_name:
             return f"{str(self.emoji)} {self.name}: {self.userName}"
-        else:
-            if self.userName:
-                return f"{str(self.emoji)} {self.userName}"
-            else:
-                return f"{str(self.emoji)}\N{ZERO WIDTH SPACE}"
+        if self.userName:
+            return f"{str(self.emoji)} {self.userName}"
+        return f"{str(self.emoji)}\N{ZERO WIDTH SPACE}"
 
     def __repr__(self):
         return f"<Role name='{self.name}' userName='{self.userName}'>"

--- a/roleGroup.py
+++ b/roleGroup.py
@@ -88,10 +88,10 @@ class RoleGroup:
             else:
                 try:
                     role = next(x for x in self.roles if x.emoji == roleEmoji)
-                except StopIteration:
+                except StopIteration as e:
                     name = roleData.get("show_name") or roleData["name"]
                     raise UnexpectedRole(f"Cannot import unexpected role "
-                                         f"'{name}'")
+                                         f"'{name}'") from e
                 roles.append(roleEmoji)
 
             role.fromJson(roleData, manual_load=manual_load)


### PR DESCRIPTION
Converters are now subclasses of the classes that they convert to. This
way linters should nag less about the command argument types.

Additionally, did some extra linting.