### PR TITLE
Add black formatter, misc linters and checkers

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -15,7 +15,7 @@
       "project_name": "Operation Bot",
       "project_slug": "operationbot",
       "project_variant": "just_a_CLI",
-      "python_version": "3.9"
+      "python_version": "3.10"
     }
   },
   "directory": null

--- a/.github/linters/.flake8
+++ b/.github/linters/.flake8
@@ -1,3 +1,12 @@
+# This config is used by Super-Linter and .pre-commit-config.yaml
 [flake8]
-# Black uses 88 as line length
-max-line-length=88
+max-line-length=79
+# Disable complaints about the use of assert in tests
+per-file-ignores=tests:S101
+# E501: line too long; replaced by B950
+# W503: line break before binary operator; against PEP8
+# D100-D107: docstrings; disabled until we have docstrings for everything
+# D400: first line period; overly strict, might be enabled at some point though
+ignore=E501,W503,D100,D101,D102,D103,D105,D107,D400
+# B950: line too long, but tolerates 10% over the limit, like black
+extend-select=B950

--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,0 +1,4 @@
+---
+# This config is used by Super-Linter and .pre-commit-config.yaml
+MD024:
+  allow_different_nesting: true

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ["3.9", "3.10"]
+        python_version: ["3.10"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 exclude: "^docs/source/conf.py$"
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v4.4.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
@@ -32,7 +32,7 @@ repos:
     name: Hadolint (Dockerfile checker)
 # Sort python imports
 - repo: https://github.com/pycqa/isort
-  rev: 5.11.2
+  rev: v5.11.3
   hooks:
   - id: isort
     name: isort (python)
@@ -44,7 +44,7 @@ repos:
     name: Black (Python formatter)
 # Python type-checker
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.982
+  rev: v0.991
   hooks:
   - id: mypy
     name: Mypy (Python type-checker)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,3 +72,8 @@ repos:
     # - "flake8-bandit==4.1.1"
     - "flake8-bugbear==22.8.23"
     - "flake8-docstrings==1.6.0"
+- repo: https://github.com/igorshubovych/markdownlint-cli
+  rev: v0.32.2
+  hooks:
+  - id: markdownlint
+    args: ["--config", ".github/linters/.markdown-lint.yml"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,14 +30,45 @@ repos:
   hooks:
   - id: hadolint
     name: Hadolint (Dockerfile checker)
-# Actual Python Linter
-- repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.0.146
+# Sort python imports
+- repo: https://github.com/pycqa/isort
+  rev: 5.11.2
   hooks:
-  - id: ruff
+  - id: isort
+    name: isort (python)
+# Python formatter
+- repo: https://github.com/psf/black
+  rev: 22.12.0
+  hooks:
+  - id: black
+    name: Black (Python formatter)
+# Python type-checker
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.982
   hooks:
   - id: mypy
     name: Mypy (Python type-checker)
     additional_dependencies: [types-PyYAML==6.0.12.2]
+# Python linter
+- repo: https://github.com/pycqa/flake8
+  rev: 6.0.0
+  hooks:
+  - id: flake8
+    name: Flake8 (Python linter)
+    # flake8 refuses to use pyproject.toml, needs a separate config.
+    # See https://github.com/PyCQA/flake8/issues/234
+    args: [
+      "--config=.github/linters/.flake8",
+      "--output-file",
+      "test_results/flake8.txt",
+      "--tee",
+      "src/",
+      "tests/"
+    ]
+    additional_dependencies:
+    # Bandit is currently disabled it because doesn't seem to respect
+    # per-file-ignores=tests:S101 and keeps complaining about asserts
+    # in tests.
+    # - "flake8-bandit==4.1.1"
+    - "flake8-bugbear==22.8.23"
+    - "flake8-docstrings==1.6.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,22 @@
 # Changelog for Operation Bot
 
-
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 The project uses semantic versioning (see [SemVer](https://semver.org)).
 
 ## [Unreleased]
 
 ### Changed
+
 - Depends on Python version 3.10
 
 ## v0.39.2 - 2022-12-15
 
 ### Changed
+
 - Added a template by OverkillGuy
 
 ## v0.39.1 - 2022-10-17
 
 ### Added
+
 - Show timezone names dynamically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The project uses semantic versioning (see [SemVer](https://semver.org)).
 
 ## [Unreleased]
 
+### Changed
+- Depends on Python version 3.10
 
 ## v0.39.2 - 2022-12-15
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-bullseye
+FROM python:3.10-bullseye
 
 # Bring poetry, our package manager, and pre-commit hooks
 ARG POETRY_VERSION=1.2.0

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM python:3.9 as builder
+FROM python:3.10 as builder
 
 # Bring poetry, our package manager
 ARG POETRY_VERSION=1.2.0
@@ -11,7 +11,7 @@ WORKDIR /workdir
 RUN poetry build -f wheel
 
 # Start over with just the binary package install
-FROM python:3.9-slim as runner
+FROM python:3.10-slim as runner
 
 COPY --from=builder /workdir/dist /app
 

--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,9 @@ release:
 # Set the new version Makefile variable after the version bump
 	$(eval NEW_VERSION := $(shell poetry version --short ${BUMP}))
 	sed -i \
-		"s/\(## \[Unreleased\]\)/\1\n\n\n## v${NEW_VERSION} - $(shell date -I)/" \
+		"s/\(## \[Unreleased\]\)/\1\n\n## v${NEW_VERSION} - $(shell date -I)/" \
 		CHANGELOG.md
-	git add -A
+	git add CHANGELOG.md pyproject.toml
 	git commit -m "Bump to version v${NEW_VERSION}"
 	git tag -a v${NEW_VERSION} \
 		-m "Release v${NEW_VERSION}"

--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,11 @@ install:
 # Enforce the pre-commit hooks
 .PHONY: install-hooks
 install-hooks:
-	pre-commit install
+	poetry run pre-commit install
 
 .PHONY: lint
 lint:  # Use all linters on all files (not just staged for commit)
-	pre-commit run --all --all-files
+	poetry run pre-commit run --all --all-files
 
 .PHONY: test
 test:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Operationbot for the Zeusops discord
 
-**Note:** Requires Python 3.9 or newer.
+**Note:** Requires Python 3.10 or newer.
 
 ## Setting up
 
@@ -41,7 +41,7 @@ Then inside the virtual environment, launch the command:
 
 ### Python setup
 
-This repository uses Python3.9, using
+This repository uses Python 3.10, using
 [Poetry](https://python-poetry.org) as package manager to define a
 Python package inside `src/operationbot/`.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@
 3. Change the channel IDs in `config.py` if the bot is not running on the Zeus
    Operations discord.
 
-4. Install the package locally (via `poetry`, get it via `pip install poetry`).
+4. Install the package locally (via `poetry`, get it via `pip install poetry`,
+   or `pipx install poetry`).
 
    ```shell
    make install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = "GPL-3.0-or-later"
 operationbot = "operationbot.cli:cli"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 # Discord bot lib
 "discord.py" = ">=1.3.4,<2.0.0"
 # Yaml parser
@@ -64,7 +64,7 @@ addopts = """-vv \
       --junit-xml=test_results/results.xml"""
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 
 [tool.ruff]
 # Black (formatter) uses 88 characters per line not PEP8's 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,10 @@ myst-parser = "*"
 # Automatic Python module docs (javadoc-style)
 sphinx-autoapi = "*"
 
+[tool.poetry.group.dev.dependencies]
+types-PyYAML = "*"
+"discord.py-stubs" = "*"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
@@ -49,6 +53,10 @@ build-backend = "poetry.core.masonry.api"
 [tool.isort]
 profile = "black"
 multi_line_output = 3
+line_length = 79
+
+[tool.black]
+line-length = 79
 
 # Avoid pointless warning about performance hit of f-string in loggers
 [tool.pylint.message_control]
@@ -65,20 +73,4 @@ addopts = """-vv \
 
 [tool.mypy]
 python_version = "3.10"
-
-[tool.ruff]
-# Black (formatter) uses 88 characters per line not PEP8's 79
-line-length = 88
-# Per-project ignored rules: show rule name + explain why ignored for whole project
-ignore = [
-    # "Use of assert detected. The enclosed code will be removed when compiling to optimised byte code."
-    # This is useless in tests/ where we WANT to have asserts
-    "S101",
-    # "Docstrings first line must end in a period"
-    # Overly strict rule don't serve anyone. PEP8 be damned on this
-    "D400",
-    # "Line too long"
-    # We have "black" formatter to deal with those (splits line), and flake8
-    # still complains about long comments(!!!) automatically
-    "E501"
-]
+check_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ sphinx-autoapi = "*"
 [tool.poetry.group.dev.dependencies]
 types-PyYAML = "*"
 "discord.py-stubs" = "*"
+pre-commit = "*"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/operationbot/bot.py
+++ b/src/operationbot/bot.py
@@ -3,10 +3,11 @@
 import logging
 import sys
 import traceback
+from typing import Any
 
 import discord
 from discord import TextChannel, User
-from discord.ext.commands import Bot, DefaultHelpCommand
+from discord.ext.commands import Bot, DefaultHelpCommand, HelpCommand
 from discord.guild import Guild
 
 from operationbot import config as cfg
@@ -23,7 +24,6 @@ class AliasHelpCommand(DefaultHelpCommand):
         Copied with modifications from discord/ext/commands/help.py
         Includes the first alias of a command in the default help message.
         """
-
         # pylint: disable=W0212
         def get_max_size(names):
             as_lengths = (
@@ -57,7 +57,12 @@ class AliasHelpCommand(DefaultHelpCommand):
 class OperationBot(Bot):
     """A custom Discord bot."""
 
-    def __init__(self, *args, help_command=None, **kwargs):
+    def __init__(
+        self,
+        *args: Any,
+        help_command: HelpCommand | None = None,
+        **kwargs: Any,
+    ):
         super().__init__(*args, **kwargs)
         self.commandchannel: TextChannel
         self.logchannel: TextChannel

--- a/src/operationbot/bot.py
+++ b/src/operationbot/bot.py
@@ -27,8 +27,7 @@ class AliasHelpCommand(DefaultHelpCommand):
         # pylint: disable=W0212
         def get_max_size(names):
             as_lengths = (
-                discord.utils._string_width(n)
-                for n in names.values()
+                discord.utils._string_width(n) for n in names.values()
             )
             return max(as_lengths, default=0)
 
@@ -42,7 +41,7 @@ class AliasHelpCommand(DefaultHelpCommand):
             name = command.name
             aliases = command.aliases
             if aliases:
-                name = f'{aliases[0]}|{name}'
+                name = f"{aliases[0]}|{name}"
             names[command.name] = name
 
         max_size = get_max_size(names)
@@ -125,11 +124,14 @@ class OperationBot(Bot):
         _, error, _ = sys.exc_info()
 
         ctx = self.commandchannel
-        msg = (f"Unexpected error occured in {event_method}: ```{error}```\n"
-               f"```py\n{trace}```")
+        msg = (
+            f"Unexpected error occured in {event_method}: ```{error}```\n"
+            f"```py\n{trace}```"
+        )
         if len(msg) >= 2000:
-            await ctx.send("Received error message that's over 2000 "
-                           "characters, check log.")
+            await ctx.send(
+                "Received error message that's over 2000 characters, check log."
+            )
             print(msg)
         else:
             await ctx.send(msg)

--- a/src/operationbot/cogs/repl.py
+++ b/src/operationbot/cogs/repl.py
@@ -9,8 +9,12 @@ from typing import Callable, Set, cast
 
 import discord
 from discord.ext import commands
-from discord.ext.commands import (BadArgument, Bot, Context,
-                                  MissingRequiredArgument)
+from discord.ext.commands import (
+    BadArgument,
+    Bot,
+    Context,
+    MissingRequiredArgument,
+)
 
 from operationbot.eventDatabase import EventDatabase  # noqa
 from operationbot.secret import COMMAND_CHAR as CMD
@@ -25,28 +29,28 @@ class REPL(commands.Cog):
     def cleanup_code(self, content):
         """Automatically removes code blocks from the code."""
         # remove ```py\n```
-        if content.startswith('```') and content.endswith('```'):
-            return '\n'.join(content.split('\n')[1:-1])
+        if content.startswith("```") and content.endswith("```"):
+            return "\n".join(content.split("\n")[1:-1])
 
         # remove `foo`
-        return content.strip('` \n')
+        return content.strip("` \n")
 
     def get_syntax_error(self, e):
         if e.text is None:
-            return f'```py\n{e.__class__.__name__}: {e}\n```'
+            return f"```py\n{e.__class__.__name__}: {e}\n```"
         return f'```py\n{e.text}{"^":>{e.offset}}\n{type(e).__name__}: {e}```'
 
-    @commands.command(name='eval', hidden=True)
+    @commands.command(name="eval", hidden=True)
     @commands.is_owner()
     async def _eval(self, ctx: Context, *, body: str):
         env = {
-            'bot': self.bot,
-            'ctx': ctx,
-            'channel': ctx.message.channel,
-            'author': ctx.message.author,
-            'guild': ctx.message.guild,
-            'message': ctx.message,
-            '_': self._last_result
+            "bot": self.bot,
+            "ctx": ctx,
+            "channel": ctx.message.channel,
+            "author": ctx.message.author,
+            "guild": ctx.message.guild,
+            "message": ctx.message,
+            "_": self._last_result,
         }
 
         env.update(globals())
@@ -61,26 +65,26 @@ class REPL(commands.Cog):
         except SyntaxError as e:
             return await ctx.send(self.get_syntax_error(e))
 
-        func = cast(Callable, env['func'])
+        func = cast(Callable, env["func"])
         try:
             with redirect_stdout(stdout):
                 ret = await func()
         except Exception:  # pylint: disable=broad-except
             value = stdout.getvalue()
-            await ctx.send(f'```py\n{value}{traceback.format_exc()}\n```')
+            await ctx.send(f"```py\n{value}{traceback.format_exc()}\n```")
         else:
             value = stdout.getvalue()
             try:
-                await ctx.message.add_reaction('\u2705')
+                await ctx.message.add_reaction("\u2705")
             except Exception:  # pylint: disable=broad-except
-                await ctx.send(f'```py\n{traceback.format_exc()}\n```')
+                await ctx.send(f"```py\n{traceback.format_exc()}\n```")
 
             if ret is None:
                 if value:
-                    await ctx.send(f'```py\n{value}\n```')
+                    await ctx.send(f"```py\n{value}\n```")
             else:
                 self._last_result = ret
-                await ctx.send(f'```py\n{value}{ret}\n```')
+                await ctx.send(f"```py\n{value}{ret}\n```")
 
     @commands.command(hidden=True)
     @commands.is_owner()
@@ -88,45 +92,49 @@ class REPL(commands.Cog):
         msg = ctx.message
 
         variables = {
-            'ctx': ctx,
-            'bot': self.bot,
-            'message': msg,
-            'guild': msg.guild,
-            'channel': msg.channel,
-            'author': msg.author,
-            'db': EventDatabase,
-            '_': None,
+            "ctx": ctx,
+            "bot": self.bot,
+            "message": msg,
+            "guild": msg.guild,
+            "channel": msg.channel,
+            "author": msg.author,
+            "db": EventDatabase,
+            "_": None,
         }
 
         if msg.channel.id in self.sessions:
             await ctx.send(
-                'Already running a REPL session in this channel.'
-                'Exit it with `quit`.')
+                "Already running a REPL session in this channel. Exit it with `quit`."
+            )
             return
 
         self.sessions.add(msg.channel.id)
-        await ctx.send('Enter code to execute or evaluate.'
-                       '`exit()` or `quit` to exit.')
+        await ctx.send(
+            "Enter code to execute or evaluate. `exit()` or `quit` to exit."
+        )
 
         def pred(m):
-            return m.author == msg.author and m.channel == msg.channel \
-                and m.content.startswith('`')
+            return (
+                m.author == msg.author
+                and m.channel == msg.channel
+                and m.content.startswith("`")
+            )
+
         while True:
-            response = await self.bot.wait_for(
-                'message', check=pred)
+            response = await self.bot.wait_for("message", check=pred)
 
             cleaned = self.cleanup_code(response.content)
 
-            if cleaned in ('quit', 'exit', 'exit()'):
-                await ctx.send('Exiting.')
+            if cleaned in ("quit", "exit", "exit()"):
+                await ctx.send("Exiting.")
                 self.sessions.remove(msg.channel.id)
                 return
 
             executor = exec
-            if cleaned.count('\n') == 0:
+            if cleaned.count("\n") == 0:
                 # single statement, potentially 'eval'
                 try:
-                    code = compile(cleaned, '<repl session>', 'eval')
+                    code = compile(cleaned, "<repl session>", "eval")
                 except SyntaxError:
                     pass
                 else:
@@ -134,12 +142,12 @@ class REPL(commands.Cog):
 
             if executor is exec:
                 try:
-                    code = compile(cleaned, '<repl session>', 'exec')
+                    code = compile(cleaned, "<repl session>", "exec")
                 except SyntaxError as e:
                     await ctx.send(self.get_syntax_error(e))
                     continue
 
-            variables['message'] = response
+            variables["message"] = response
 
             fmt = None
             stdout = io.StringIO()
@@ -151,26 +159,26 @@ class REPL(commands.Cog):
                         result = await result
             except Exception:  # pylint: disable=broad-except
                 value = stdout.getvalue()
-                fmt = f'```py\n{value}{traceback.format_exc()}\n```'
+                fmt = f"```py\n{value}{traceback.format_exc()}\n```"
             else:
                 value = stdout.getvalue()
                 if result is not None:
-                    fmt = f'```py\n{value}{result}\n```'
-                    variables['_'] = result
+                    fmt = f"```py\n{value}{result}\n```"
+                    variables["_"] = result
                 elif value:
-                    fmt = f'```py\n{value}\n```'
+                    fmt = f"```py\n{value}\n```"
 
             try:
                 if fmt is not None:
                     if len(fmt) > 2000:
-                        await ctx.send('Content too big to be printed.')
+                        await ctx.send("Content too big to be printed.")
                         print(fmt)
                     else:
                         await ctx.send(fmt)
             except discord.Forbidden:
                 pass
             except discord.HTTPException as e:
-                await ctx.send(f'Unexpected error: `{e}`')
+                await ctx.send(f"Unexpected error: `{e}`")
 
     @repl.error
     @_eval.error
@@ -178,8 +186,9 @@ class REPL(commands.Cog):
         if isinstance(error, MissingRequiredArgument):
             await ctx.send(f"Missing argument. See: {CMD}help {ctx.command}")
         elif isinstance(error, BadArgument):
-            await ctx.send(f"Invalid argument: {error}. See: {CMD}help "
-                           f"{ctx.command}")
+            await ctx.send(
+                f"Invalid argument: {error}. See: {CMD}help {ctx.command}"
+            )
         else:
             await ctx.send(f"Unexpected error occured: ```{error}```")
             print(error)

--- a/src/operationbot/cogs/repl.py
+++ b/src/operationbot/cogs/repl.py
@@ -16,7 +16,7 @@ from discord.ext.commands import (
     MissingRequiredArgument,
 )
 
-from operationbot.eventDatabase import EventDatabase  # noqa
+from operationbot.eventDatabase import EventDatabase
 from operationbot.secret import COMMAND_CHAR as CMD
 
 

--- a/src/operationbot/commandListener.py
+++ b/src/operationbot/commandListener.py
@@ -19,6 +19,7 @@ from discord.ext.commands.errors import (
 
 from operationbot import config as cfg
 from operationbot import messageFunctions as msgFnc
+from operationbot.bot import OperationBot
 from operationbot.converters import (
     ArgArchivedEvent,
     ArgDate,
@@ -33,7 +34,6 @@ from operationbot.converters import (
 from operationbot.errors import MessageNotFound, RoleError, UnexpectedRole
 from operationbot.event import Event
 from operationbot.eventDatabase import EventDatabase
-from operationbot.bot import OperationBot
 from operationbot.role import Role
 from operationbot.roleGroup import RoleGroup
 from operationbot.secret import ADMINS
@@ -63,8 +63,7 @@ class CommandListener(Cog):
 
         @bot.check
         async def command_channels_only(ctx: Context):
-            """Prevents the bot from being controlled outside of the specified
-            command and debug channels."""
+            """Prevent commands from being used outside of the command channel."""
             # pylint: disable=protected-access
             return (
                 ctx.channel == self.bot.commandchannel
@@ -73,8 +72,7 @@ class CommandListener(Cog):
 
     @command()
     async def testrole(self, ctx: Context, event: ArgEvent, role: ArgRole):
-        """
-        Test role parser.
+        """Test role parser.
 
         This command finds and displays roles from the given event. For testing purposes only.
         """  # NOQA
@@ -82,8 +80,7 @@ class CommandListener(Cog):
 
     @command(aliases=["t"])
     async def testmember(self, ctx: Context, member: ArgMember):
-        """
-        Test role parser.
+        """Test role parser.
 
         This command finds and displays roles from the given event. For testing purposes only.
         """  # NOQA
@@ -91,14 +88,12 @@ class CommandListener(Cog):
 
     @command()
     async def roleparserinfo(self, ctx: Context):
-        """
-        Display information about parsing roles.
-        """
-
+        """Display information about parsing roles."""
         if ArgRole.__doc__:
             doc = ArgRole.__doc__.split("\n\n")[2]
             await ctx.send(
-                f"How to use commands that use ArgRole for parsing roles: \n\n{doc}"
+                f"How to use commands that use ArgRole for "
+                f"parsing roles: \n\n{doc}"
             )
         else:
             await ctx.send("No documentation found")
@@ -125,8 +120,7 @@ class CommandListener(Cog):
 
     @command()
     async def exec(self, ctx: Context, flag: str, *, cmd: str):
-        """
-        Execute arbitrary code.
+        """Execute arbitrary code.
 
         If <flag> is p, the result gets wrapped in a print() statement
         If <flag> is c, the result gets printed in console
@@ -159,7 +153,10 @@ class CommandListener(Cog):
                 msg = "Executed"
             # sys.stdout = old_stdout
         except Exception:  # pylint: disable=broad-except
-            msg = f"An error occured while executing: ```py\n{traceback.format_exc()}```"
+            msg = (
+                "An error occured while executing: "
+                f"```py\n{traceback.format_exc()}```"
+            )
         await ctx.send(msg)
 
     async def _create_event(
@@ -209,11 +206,10 @@ class CommandListener(Cog):
         self,
         ctx: Context,
         _datetime: ArgDateTime,
-        force=None,
+        force=False,
         platoon_size=None,
     ):
-        """
-        Create a new event.
+        """Create a new event.
 
         Use the `force` argument to create past events.
 
@@ -223,39 +219,34 @@ class CommandListener(Cog):
                  create 2019-01-01 force
                  create 2019-01-01 force 2PLT
         """  # NOQA
-
         await self._create_event(
             ctx, _datetime, platoon_size=platoon_size, force=force
         )
 
     @command(aliases=["cs"])
     async def createside(
-        self, ctx: Context, _datetime: ArgDateTime, force=None
+        self, ctx: Context, _datetime: ArgDateTime, force=False
     ):
-        """
-        Create a new side op event.
+        """Create a new side op event.
 
         Use the `force` argument to create past events.
 
         Example: createside 2019-01-01
                  createside 2019-01-01 force
         """
-
         await self._create_event(ctx, _datetime, sideop=True, force=force)
 
     @command(aliases=["cs2"])
     async def createside2(
-        self, ctx: Context, _datetime: ArgDateTime, force=None
+        self, ctx: Context, _datetime: ArgDateTime, force=False
     ):
-        """
-        Create a new WW2 side op event.
+        """Create a new WW2 side op event.
 
         Use the `force` argument to create past events.
 
         Example: createside2 2019-01-01
                  createside2 2019-01-01 force
         """
-
         await self._create_event(
             ctx, _datetime, sideop=True, platoon_size="WW2side", force=force
         )
@@ -266,10 +257,10 @@ class CommandListener(Cog):
         _datetime: ArgDateTime,
         terrain: str,
         faction: str,
-        zeus: Member = None,
-        _time: ArgTime = None,
+        zeus: Member | None = None,
+        _time: ArgTime | None = None,
         sideop=False,
-        platoon_size: str = None,
+        platoon_size: str | None = None,
         quiet=False,
     ):
         if _time is not None:
@@ -302,11 +293,10 @@ class CommandListener(Cog):
         _datetime: ArgDateTime,
         terrain: str,
         faction: str,
-        zeus: ArgMember = None,
-        _time: ArgTime = None,
+        zeus: ArgMember | None = None,
+        _time: ArgTime | None = None,
     ):
-        """
-        Create and pre-fill a main op event.
+        """Create and pre-fill a main op event.
 
         Define the event time to force creation of past events.
 
@@ -326,11 +316,11 @@ class CommandListener(Cog):
         _datetime: ArgDateTime,
         terrain: str,
         faction: str,
-        zeus: ArgMember = None,
-        _time: ArgTime = None,
+        # NOTE: Optional[] is required by discord.py (instead of Arg | None)
+        zeus: Optional[ArgMember] = None,
+        _time: Optional[ArgTime] = None,
     ):
-        """
-        Create and pre-fill a side op event.
+        """Create and pre-fill a side op event.
 
         Define the event time to force creation of past events.
 
@@ -350,11 +340,10 @@ class CommandListener(Cog):
         _datetime: ArgDateTime,
         terrain: str,
         faction: str,
-        zeus: ArgMember = None,
-        _time: ArgTime = None,
+        zeus: Optional[ArgMember] = None,
+        _time: Optional[ArgTime] = None,
     ):
-        """
-        Create and pre-fill a WW2 side op event. Automatically sets description.
+        """Create and pre-fill a WW2 side op event. Automatically sets description.
 
         Define the event time to force creation of past events.
 
@@ -378,7 +367,11 @@ class CommandListener(Cog):
 
     @command(aliases=["mc"])
     async def multicreate(
-        self, ctx: Context, start: ArgDate, end: ArgDate = None, force=None
+        self,
+        ctx: Context,
+        start: ArgDate,
+        end: Optional[ArgDate] = None,
+        force=False,
     ):
         """Create events for all weekends within specified range.
 
@@ -392,7 +385,7 @@ class CommandListener(Cog):
         await self._multi_create(ctx, start, end, force)
 
     async def _multi_create(
-        self, ctx: Context, start: date, end: date = None, force=None
+        self, ctx: Context, start: date, end: date | None = None, force=False
     ):
         if end is None:
             last_day = calendar.monthrange(start.year, start.month)[1]
@@ -533,7 +526,8 @@ class CommandListener(Cog):
         except IndexError as e:
             user = self.bot.owner
             raise RoleError(
-                f"Too many additional roles. This should not happen. Nag at {user.mention}"
+                "Too many additional roles. This should not happen. "
+                f"Nag at {user.mention}"
             ) from e
         except RoleError as e:
             if batch:
@@ -546,8 +540,7 @@ class CommandListener(Cog):
     async def addrole(
         self, ctx: Context, event: ArgEvent, *, rolename: UnquotedStr
     ):
-        """
-        Add a new additional role or multiple roles to the event.
+        """Add a new additional role or multiple roles to the event.
 
         Separate different roles with a newline
 
@@ -582,8 +575,7 @@ class CommandListener(Cog):
     async def removerole(
         self, ctx: Context, event: ArgEvent, *, role: ArgRole
     ):
-        """
-        Remove an additional role from the event.
+        """Remove an additional role from the event.
 
         Example: removerole 1 Y1 (Bradley) Driver
         """
@@ -602,8 +594,7 @@ class CommandListener(Cog):
         *,
         new_name: UnquotedStr,
     ):
-        """
-        Rename an additional role of the event.
+        """Rename an additional role of the event.
 
         Example: renamerole 1 1 "Y2 (Bradley) Driver"
                  rename 1 two "Y2 (Bradley) Driver"
@@ -620,9 +611,7 @@ class CommandListener(Cog):
     async def removereaction(
         self, ctx: Context, event: ArgEvent, reaction: str
     ):
-        """
-        Removes a role and the corresponding reaction from the event and updates the message.
-        """  # NOQA
+        """Remove a role and the reaction from the event, update message."""
         self._find_remove_reaction(reaction, event)
         await self._update_event(event, reorder=False)
         await ctx.send(f"Reaction {reaction} removed from {event}")
@@ -640,8 +629,7 @@ class CommandListener(Cog):
     async def removegroup(
         self, ctx: Context, eventMessage: ArgMessage, *, groupName: UnquotedStr
     ):
-        """
-        Remove a role group from the event.
+        """Remove a role group from the event.
 
         Example: removegroup 1 Bravo
         """
@@ -665,8 +653,7 @@ class CommandListener(Cog):
     async def settitle(
         self, ctx: Context, event: ArgEvent, *, title: UnquotedStr
     ):
-        """
-        Set event title.
+        """Set event title.
 
         Example: settitle 1 Operation Striker
         """
@@ -676,7 +663,8 @@ class CommandListener(Cog):
         event.title = title
         await self._update_event(event)
         await ctx.send(
-            f"Title {event.title} set for operation ID {event.id} at {event.date}"
+            f"Title {event.title} set for operation "
+            f"ID {event.id} at {event.date}"
         )
         await self._show(ctx, event)
 
@@ -685,8 +673,7 @@ class CommandListener(Cog):
     async def setdate(
         self, ctx: Context, event: ArgEvent, _datetime: ArgDateTime
     ):
-        """
-        Set event date.
+        """Set event date.
 
         Example: setdate 1 2019-01-01
         """
@@ -706,8 +693,7 @@ class CommandListener(Cog):
     async def settime(
         self, ctx: Context, event: ArgEvent, event_time: ArgTime
     ):
-        """
-        Set event time.
+        """Set event time.
 
         Example: settime 1 18:30
         """
@@ -725,8 +711,7 @@ class CommandListener(Cog):
     async def setterrain(
         self, ctx: Context, event: ArgEvent, *, terrain: UnquotedStr
     ):
-        """
-        Set event terrain.
+        """Set event terrain.
 
         Example: settime 1 Takistan
         """
@@ -741,8 +726,7 @@ class CommandListener(Cog):
     async def setfaction(
         self, ctx: Context, event: ArgEvent, *, faction: UnquotedStr
     ):
-        """
-        Set event faction.
+        """Set event faction.
 
         Example: setfaction 1 Insurgents
         """
@@ -774,17 +758,18 @@ class CommandListener(Cog):
         *,
         description: UnquotedStr = "",  # type: ignore
     ):
-        """
-        Set or clear event description. To clear the description, run `setdescription [ID]` without the description parameter
+        """Set or clear event description.
+
+        To clear the description, run `setdescription [ID]` without the
+        description parameter.
 
         Example: setdescription 1 Extra mods required
-        """  # NOQA
+        """
         await self._set_description(ctx, event, description)
 
     @command(aliases=["cld"])
     async def cleardescription(self, ctx: Context, event: ArgEvent):
-        """
-        Clear event description. Alias for `setdescription [ID]`
+        """Clear event description. Alias for `setdescription [ID]`
 
         Example: cleardescription 1
         """
@@ -805,8 +790,9 @@ class CommandListener(Cog):
     async def setport(
         self, ctx: Context, event: ArgEvent, port: int = cfg.PORT_DEFAULT
     ):
-        """
-        Set or clear event server port. To clear the port, run `setport [ID]` without the port parameter
+        """Set or clear event server port.
+
+        To clear the port, run `setport [ID]` without the port parameter.
 
         Example: setport 1 2402
         """  # NOQA
@@ -814,8 +800,7 @@ class CommandListener(Cog):
 
     @command(aliases=["clp"])
     async def clearport(self, ctx: Context, event: ArgEvent):
-        """
-        Clear event port. Alias for `setport [ID]`
+        """Clear event port. Alias for `setport [ID]`
 
         Example: clearport 1
         """
@@ -842,22 +827,22 @@ class CommandListener(Cog):
         *,
         mods: UnquotedStr = "",  # type: ignore
     ):
-        """
-        Set or clear event server mods.
+        """Set or clear event server mods.
 
-        To clear the mods, run `setmods [ID]` without the mods parameter. Adding mods also sets the server port to the configured sideop port. Removing the mods sets the server port to the default port.
+        To clear the mods, run `setmods [ID]` without the mods parameter.
+        Adding mods also sets the server port to the configured sideop port.
+        Removing the mods sets the server port to the default port.
 
         Example: setmods 1 Custom modset
                  setmods 1 Mod 1
                    Mod 2
                    Mod 3
-        """  # NOQA
+        """
         await self._set_mods(ctx, event, mods)
 
     @command(aliases=["clm", "clearmod"])
     async def clearmods(self, ctx: Context, event: ArgEvent):
-        """
-        Clear event mods. Alias for `setmods [ID]`
+        """Clear event mods. Alias for `setmods [ID]`
 
         Example: clearmods 1
         """
@@ -869,8 +854,8 @@ class CommandListener(Cog):
         event: Event,
         terrain: str,
         faction: str,
-        zeus: Member = None,
-        _time: ArgTime = None,
+        zeus: Member | None = None,
+        _time: ArgTime | None = None,
         quiet=False,
     ):
         event.terrain = terrain
@@ -896,11 +881,10 @@ class CommandListener(Cog):
         event: ArgEvent,
         terrain: str,
         faction: str,
-        zeus: ArgMember = None,
-        _time: ArgTime = None,
+        zeus: Optional[ArgMember] = None,
+        _time: Optional[ArgTime] = None,
     ):
-        """
-        Quickly set event details.
+        """Quickly set event details.
 
         Accepted formats for the optional `time` argument: HH:MM and HHMM. Default time: 18:30
 
@@ -915,8 +899,7 @@ class CommandListener(Cog):
     async def signup(
         self, ctx: Context, event: ArgEvent, user: ArgMember, *, role: ArgRole
     ):
-        """
-        Sign user up to a role.
+        """Sign user up to a role.
 
         Removes user's previous signup from another role and overrides existing signup to the target role, if any.
 
@@ -928,7 +911,10 @@ class CommandListener(Cog):
         # Sign user up, update event, export
         old_signup, replaced_user = event.signup(role, user, replace=True)
         await self._update_event(event)
-        message = f"User {user.display_name} signed up to event {event} as {role.name}"
+        message = (
+            f"User {user.display_name} signed up to "
+            f"event {event} as {role.name}"
+        )
         if old_signup:
             # User was signed on to a different role previously
             message += f". Signed off from {old_signup.name}"
@@ -943,8 +929,7 @@ class CommandListener(Cog):
     async def removesignup(
         self, ctx: Context, event: ArgEvent, user: ArgMember
     ):
-        """
-        Undo user signup (manually).
+        """Undo user's signup.
 
         <user> can either be: ID, mention, nickname in quotes, username or username#discriminator
 
@@ -955,23 +940,23 @@ class CommandListener(Cog):
         if role:
             await self._update_event(event)
             await ctx.send(
-                f"User {user.display_name} removed from role {role.display_name} in event {event}"
+                f"User {user.display_name} removed from "
+                f"role {role.display_name} in event {event}"
             )
             await self._show(ctx, event)
         else:
             await ctx.send(
-                f"No signup to remove for user {user.display_name} in event {event}"
+                f"No signup to remove for user {user.display_name} "
+                f"in event {event}"
             )
 
     # Archive event command
     @command(aliases=["a"])
     async def archive(self, ctx: Context, event: ArgEvent):
-        """
-        Archive event.
+        """Archive event.
 
         Example: archive 1
         """
-
         # Archive event and export
         EventDatabase.archiveEvent(event)
         try:
@@ -1005,8 +990,7 @@ class CommandListener(Cog):
     # Delete event command
     @command(aliases=["d"])
     async def delete(self, ctx: Context, event: ArgEvent):
-        """
-        Delete event.
+        """Delete event.
 
         Example: delete 1
         """
@@ -1015,8 +999,7 @@ class CommandListener(Cog):
 
     @command()
     async def deletearchived(self, ctx: Context, event: ArgArchivedEvent):
-        """
-        Delete archived event.
+        """Delete archived event.
 
         Example: deletearchived 1
         """
@@ -1058,7 +1041,9 @@ class CommandListener(Cog):
         await ctx.send(f"{len(EventDatabase.events)} events imported")
 
     @command()
-    async def dump(self, ctx: Context, event: ArgEvent, roleGroup: str = None):
+    async def dump(
+        self, ctx: Context, event: ArgEvent, roleGroup: Optional[str] = None
+    ):
         """Dump given event as YAML for mass editing.
 
         Use `load` to import the data back in after editing. Specify roleGroup
@@ -1109,7 +1094,7 @@ class CommandListener(Cog):
         event: Event,
         data: str,
         emojis: Tuple[Emoji, ...],
-        target: TextChannel = None,
+        target: TextChannel | None = None,
     ):
         if data.startswith("```") and data.endswith("```"):
             # Remove the first line (containing ```yaml) and the last three
@@ -1203,7 +1188,8 @@ class CommandListener(Cog):
         elif isinstance(error, CommandInvokeError):
             if isinstance(error.original, UnexpectedRole):
                 await ctx.send(
-                    f"Malformed data: {error.original}. See: `{CMD}help {ctx.command}`"
+                    f"Malformed data: {error.original}. "
+                    f"See: `{CMD}help {ctx.command}`"
                 )
                 return
             elif isinstance(error.original, RoleError):

--- a/src/operationbot/commandListener.py
+++ b/src/operationbot/commandListener.py
@@ -11,14 +11,25 @@ from discord import Member
 from discord.channel import TextChannel
 from discord.emoji import Emoji
 from discord.ext.commands import BadArgument, Cog, Context, command
-from discord.ext.commands.errors import (CommandError, CommandInvokeError,
-                                         MissingRequiredArgument)
+from discord.ext.commands.errors import (
+    CommandError,
+    CommandInvokeError,
+    MissingRequiredArgument,
+)
 
 from operationbot import config as cfg
 from operationbot import messageFunctions as msgFnc
-from operationbot.converters import (ArgArchivedEvent, ArgDate, ArgDateTime,
-                                     ArgEvent, ArgMember, ArgMessage, ArgRole,
-                                     ArgTime, UnquotedStr)
+from operationbot.converters import (
+    ArgArchivedEvent,
+    ArgDate,
+    ArgDateTime,
+    ArgEvent,
+    ArgMember,
+    ArgMessage,
+    ArgRole,
+    ArgTime,
+    UnquotedStr,
+)
 from operationbot.errors import MessageNotFound, RoleError, UnexpectedRole
 from operationbot.event import Event
 from operationbot.eventDatabase import EventDatabase
@@ -31,7 +42,6 @@ from operationbot.secret import WW2_MODS
 
 
 class CommandListener(Cog):
-
     def __init__(self, bot: OperationBot):
         self.bot = bot
 
@@ -45,8 +55,9 @@ class CommandListener(Cog):
                 await ctx.send("Please answer the previous prompt first.")
                 return False
             if self.bot.processing:
-                await ctx.send("Please wait for the previous operation to "
-                               "finish first.")
+                await ctx.send(
+                    "Please wait for the previous operation to finish first."
+                )
                 return False
             return True
 
@@ -55,12 +66,13 @@ class CommandListener(Cog):
             """Prevents the bot from being controlled outside of the specified
             command and debug channels."""
             # pylint: disable=protected-access
-            return (ctx.channel == self.bot.commandchannel
-                    or ctx.channel.id == cfg._test_channel)
+            return (
+                ctx.channel == self.bot.commandchannel
+                or ctx.channel.id == cfg._test_channel
+            )
 
     @command()
-    async def testrole(self, ctx: Context, event: ArgEvent,
-                       role: ArgRole):
+    async def testrole(self, ctx: Context, event: ArgEvent, role: ArgRole):
         """
         Test role parser.
 
@@ -68,7 +80,7 @@ class CommandListener(Cog):
         """  # NOQA
         await ctx.send(f"event {event.id}: {role}")
 
-    @command(aliases=['t'])
+    @command(aliases=["t"])
     async def testmember(self, ctx: Context, member: ArgMember):
         """
         Test role parser.
@@ -84,16 +96,17 @@ class CommandListener(Cog):
         """
 
         if ArgRole.__doc__:
-            doc = ArgRole.__doc__.split('\n\n')[2]
-            await ctx.send(f"How to use commands that use ArgRole for "
-                           f"parsing roles: \n\n{doc}")
+            doc = ArgRole.__doc__.split("\n\n")[2]
+            await ctx.send(
+                f"How to use commands that use ArgRole for parsing roles: \n\n{doc}"
+            )
         else:
             await ctx.send("No documentation found")
 
     @command()
     async def reloadreload(self, ctx: Context):
-        self.bot.unload_extension('reload')
-        self.bot.load_extension('reload')
+        self.bot.unload_extension("reload")
+        self.bot.load_extension("reload")
         await ctx.send("Reloaded reload")
 
     @command()
@@ -104,8 +117,9 @@ class CommandListener(Cog):
         except ImportError as e:
             await ctx.send(f"Failed to reload module {moduleName}: {str(e)}")
         except Exception as e:  # pylint: disable=broad-except
-            await ctx.send("An error occured while reloading: "
-                           f"```py\n{str(e)}```")
+            await ctx.send(
+                f"An error occured while reloading: ```py\n{str(e)}```"
+            )
         else:
             await ctx.send(f"Reloaded {moduleName}")
 
@@ -128,12 +142,12 @@ class CommandListener(Cog):
         try:
             old_stdout = sys.stdout
             redirected_output = sys.stdout = StringIO()
-            if flag == 'p':
+            if flag == "p":
                 cmd = f"print({cmd})"
                 exec(cmd)  # pylint: disable=exec-used
                 sys.stdout = old_stdout
                 msg = f"```py\n{redirected_output.getvalue()}```"
-            elif flag == 'c':
+            elif flag == "c":
                 cmd = f"print({cmd})"
                 exec(cmd)  # pylint: disable=exec-used
                 sys.stdout = old_stdout
@@ -145,22 +159,30 @@ class CommandListener(Cog):
                 msg = "Executed"
             # sys.stdout = old_stdout
         except Exception:  # pylint: disable=broad-except
-            msg = ("An error occured while executing: "
-                   f"```py\n{traceback.format_exc()}```")
+            msg = f"An error occured while executing: ```py\n{traceback.format_exc()}```"
         await ctx.send(msg)
 
-    async def _create_event(self, ctx: Context, _date: datetime,
-                            batch=False, sideop=False,
-                            platoon_size=None, force=False,
-                            silent=False) -> Event:
+    async def _create_event(
+        self,
+        ctx: Context,
+        _date: datetime,
+        batch=False,
+        sideop=False,
+        platoon_size=None,
+        force=False,
+        silent=False,
+    ) -> Event:
         # TODO: Check for duplicate event dates?
         if _date < datetime.today() and not force:
-            raise BadArgument(f"Requested date {_date} has already passed. "
-                              "Use the `force` argument to override")
+            raise BadArgument(
+                f"Requested date {_date} has already passed. "
+                "Use the `force` argument to override"
+            )
 
         # Create event and sort events, export
-        event: Event = EventDatabase.createEvent(_date, sideop=sideop,
-                                                 platoon_size=platoon_size)
+        event: Event = EventDatabase.createEvent(
+            _date, sideop=sideop, platoon_size=platoon_size
+        )
         await msgFnc.createEventMessage(event, self.bot.eventchannel)
         if not batch:
             await msgFnc.sortEventMessages(self.bot)
@@ -173,17 +195,23 @@ class CommandListener(Cog):
     async def _show(self, ctx: Context, event: Event):
         message = await msgFnc.getEventMessage(event, self.bot)
         await ctx.send(f"<{message.jump_url}>")
-        await msgFnc.createEventMessage(event, cast(TextChannel, ctx.channel),
-                                        update_id=False)
+        await msgFnc.createEventMessage(
+            event, cast(TextChannel, ctx.channel), update_id=False
+        )
 
     @command(aliases=["cat"])
     async def show(self, ctx: Context, event: ArgEvent):
         await self._show(ctx, event)
 
     # Create event command
-    @command(aliases=['c'])
-    async def create(self, ctx: Context, _datetime: ArgDateTime, force=None,
-                     platoon_size=None):
+    @command(aliases=["c"])
+    async def create(
+        self,
+        ctx: Context,
+        _datetime: ArgDateTime,
+        force=None,
+        platoon_size=None,
+    ):
         """
         Create a new event.
 
@@ -196,12 +224,14 @@ class CommandListener(Cog):
                  create 2019-01-01 force 2PLT
         """  # NOQA
 
-        await self._create_event(ctx, _datetime, platoon_size=platoon_size,
-                                 force=force)
+        await self._create_event(
+            ctx, _datetime, platoon_size=platoon_size, force=force
+        )
 
-    @command(aliases=['cs'])
-    async def createside(self, ctx: Context, _datetime: ArgDateTime,
-                         force=None):
+    @command(aliases=["cs"])
+    async def createside(
+        self, ctx: Context, _datetime: ArgDateTime, force=None
+    ):
         """
         Create a new side op event.
 
@@ -213,9 +243,10 @@ class CommandListener(Cog):
 
         await self._create_event(ctx, _datetime, sideop=True, force=force)
 
-    @command(aliases=['cs2'])
-    async def createside2(self, ctx: Context, _datetime: ArgDateTime,
-                          force=None):
+    @command(aliases=["cs2"])
+    async def createside2(
+        self, ctx: Context, _datetime: ArgDateTime, force=None
+    ):
         """
         Create a new WW2 side op event.
 
@@ -225,20 +256,36 @@ class CommandListener(Cog):
                  createside2 2019-01-01 force
         """
 
-        await self._create_event(ctx, _datetime, sideop=True,
-                                 platoon_size="WW2side", force=force)
+        await self._create_event(
+            ctx, _datetime, sideop=True, platoon_size="WW2side", force=force
+        )
 
     async def _create_quick(
-            self, ctx: Context, _datetime: ArgDateTime, terrain: str,
-            faction: str, zeus: Member = None, _time: ArgTime = None,
-            sideop=False, platoon_size: str = None, quiet=False):
+        self,
+        ctx: Context,
+        _datetime: ArgDateTime,
+        terrain: str,
+        faction: str,
+        zeus: Member = None,
+        _time: ArgTime = None,
+        sideop=False,
+        platoon_size: str = None,
+        quiet=False,
+    ):
         if _time is not None:
-            _datetime = _datetime.replace(hour=_time.hour,  # type: ignore
-                                          minute=_time.minute)
+            _datetime = _datetime.replace(
+                hour=_time.hour, minute=_time.minute  # type: ignore
+            )
 
         event = await self._create_event(
-            ctx, _datetime, sideop=sideop, platoon_size=platoon_size,
-            force=(_time is not None), batch=True, silent=True)
+            ctx,
+            _datetime,
+            sideop=sideop,
+            platoon_size=platoon_size,
+            force=(_time is not None),
+            batch=True,
+            silent=True,
+        )
 
         await self._set_quick(ctx, event, terrain, faction, zeus, quiet=True)
 
@@ -248,10 +295,16 @@ class CommandListener(Cog):
             await self._show(ctx, event)
         return event
 
-    @command(aliases=['cq'])
+    @command(aliases=["cq"])
     async def createquick(
-            self, ctx: Context, _datetime: ArgDateTime, terrain: str,
-            faction: str, zeus: ArgMember = None, _time: ArgTime = None):
+        self,
+        ctx: Context,
+        _datetime: ArgDateTime,
+        terrain: str,
+        faction: str,
+        zeus: ArgMember = None,
+        _time: ArgTime = None,
+    ):
         """
         Create and pre-fill a main op event.
 
@@ -262,13 +315,20 @@ class CommandListener(Cog):
         Example: createquick 2019-01-01 Altis USMC Stroker
                  createquick 2019-01-01 Altis USMC Stroker 17:30
         """  # NOQA
-        await self._create_quick(ctx, _datetime, terrain, faction, zeus, _time,
-                                 sideop=False)
+        await self._create_quick(
+            ctx, _datetime, terrain, faction, zeus, _time, sideop=False
+        )
 
-    @command(aliases=['csq'])
+    @command(aliases=["csq"])
     async def createsidequick(
-            self, ctx: Context, _datetime: ArgDateTime, terrain: str,
-            faction: str, zeus: ArgMember = None, _time: ArgTime = None):
+        self,
+        ctx: Context,
+        _datetime: ArgDateTime,
+        terrain: str,
+        faction: str,
+        zeus: ArgMember = None,
+        _time: ArgTime = None,
+    ):
         """
         Create and pre-fill a side op event.
 
@@ -279,13 +339,20 @@ class CommandListener(Cog):
         Example: createsidequick 2019-01-01 Altis USMC Stroker
                  createsidequick 2019-01-01 Altis USMC Stroker 17:30
         """  # NOQA
-        await self._create_quick(ctx, _datetime, terrain, faction, zeus, _time,
-                                 sideop=True)
+        await self._create_quick(
+            ctx, _datetime, terrain, faction, zeus, _time, sideop=True
+        )
 
-    @command(aliases=['csq2'])
+    @command(aliases=["csq2"])
     async def createside2quick(
-            self, ctx: Context, _datetime: ArgDateTime, terrain: str,
-            faction: str, zeus: ArgMember = None, _time: ArgTime = None):
+        self,
+        ctx: Context,
+        _datetime: ArgDateTime,
+        terrain: str,
+        faction: str,
+        zeus: ArgMember = None,
+        _time: ArgTime = None,
+    ):
         """
         Create and pre-fill a WW2 side op event. Automatically sets description.
 
@@ -296,15 +363,23 @@ class CommandListener(Cog):
         Example: createside2quick 2019-01-01 Altis USMC Stroker
                  createside2quick 2019-01-01 Altis USMC Stroker 17:30
         """  # NOQA
-        event = await self._create_quick(ctx, _datetime, terrain, faction,
-                                         zeus, _time, sideop=True,
-                                         platoon_size="WW2side")
+        event = await self._create_quick(
+            ctx,
+            _datetime,
+            terrain,
+            faction,
+            zeus,
+            _time,
+            sideop=True,
+            platoon_size="WW2side",
+        )
         if WW2_MODS:
             await self._set_mods(ctx, event, WW2_MODS)
 
-    @command(aliases=['mc'])
-    async def multicreate(self, ctx: Context, start: ArgDate,
-                          end: ArgDate = None, force=None):
+    @command(aliases=["mc"])
+    async def multicreate(
+        self, ctx: Context, start: ArgDate, end: ArgDate = None, force=None
+    ):
         """Create events for all weekends within specified range.
 
         If the end date is omitted, events are created for the rest of the
@@ -316,8 +391,9 @@ class CommandListener(Cog):
         """
         await self._multi_create(ctx, start, end, force)
 
-    async def _multi_create(self, ctx: Context, start: date,
-                            end: date = None, force=None):
+    async def _multi_create(
+        self, ctx: Context, start: date, end: date = None, force=None
+    ):
         if end is None:
             last_day = calendar.monthrange(start.year, start.month)[1]
             end = start.replace(day=last_day)
@@ -339,7 +415,8 @@ class CommandListener(Cog):
             strpastdays = " ".join([day.isoformat() for day in past_days])
             strpast = (
                 "\nFollowing dates are in the past and will be skipped:\n"
-                f"```{strpastdays}```")
+                f"```{strpastdays}```"
+            )
         else:
             strpast = ""
 
@@ -348,31 +425,32 @@ class CommandListener(Cog):
             message = (
                 f"Creating events for following days:\n```{strdays}``` "
                 f"{strpast}"
-                "Reply with `ok` or `cancel`.")
+                "Reply with `ok` or `cancel`."
+            )
             await ctx.send(message)
         else:
             message = (
                 f"No events to be created.{strpast}"
                 "Use the `force` argument to override. "
-                f"See `{CMD}help multicreate`")
+                f"See `{CMD}help multicreate`"
+            )
             await ctx.send(message)
             return
 
         self.bot.awaiting_reply = True
 
         def pred(m):
-            return m.author == ctx.message.author \
-                   and m.channel == ctx.channel
+            return m.author == ctx.message.author and m.channel == ctx.channel
 
         event_time = time(hour=18, minute=30)
         with_time = [datetime.combine(day, event_time) for day in days]
 
         try:
             while True:
-                response = await self.bot.wait_for('message', check=pred)
+                response = await self.bot.wait_for("message", check=pred)
                 reply = response.content.lower()
 
-                if reply == 'ok':
+                if reply == "ok":
                     await ctx.send("Creating events")
                     for day in with_time:
                         await self._create_event(ctx, day, batch=True)
@@ -381,16 +459,16 @@ class CommandListener(Cog):
                     await ctx.send("Done creating events")
                     self.bot.awaiting_reply = False
                     return
-                if reply == 'cancel':
+                if reply == "cancel":
                     await ctx.send("Canceling")
                     self.bot.awaiting_reply = False
                     return
                 await ctx.send("Please reply with `ok` or `cancel`.")
         except Exception:  # pylint: disable=broad-except
-            await ctx.send(f'```py\n{traceback.format_exc()}\n```')
+            await ctx.send(f"```py\n{traceback.format_exc()}\n```")
             self.bot.awaiting_reply = False
 
-    @command(aliases=['csz'])
+    @command(aliases=["csz"])
     async def changesize(self, ctx: Context, event: ArgEvent, new_size: str):
         if new_size not in cfg.PLATOON_SIZES:
             await ctx.send(f"Invalid new size {new_size}")
@@ -409,7 +487,7 @@ class CommandListener(Cog):
         await self._update_event(event)
         await ctx.send("Event resized succesfully")
 
-    @command(aliases=['csza'])
+    @command(aliases=["csza"])
     async def changesizeall(self, ctx: Context, new_size: str):
         if new_size not in cfg.PLATOON_SIZES:
             await ctx.send(f"Invalid new size {new_size}")
@@ -421,7 +499,7 @@ class CommandListener(Cog):
         await ctx.send("All events resized succesfully")
         EventDatabase.toJson()
 
-    @command(aliases=['ro'])
+    @command(aliases=["ro"])
     async def reorder(self, ctx: Context, event: ArgEvent):
         ret = event.reorder()
         if ret is None:
@@ -433,7 +511,7 @@ class CommandListener(Cog):
         await self._update_event(event)
         await ctx.send("Event reordered succesfully")
 
-    @command(aliases=['roa'])
+    @command(aliases=["roa"])
     async def resizeall(self, ctx: Context):
         for event in EventDatabase.events.values():
             print("reordering", event)
@@ -454,8 +532,9 @@ class CommandListener(Cog):
             event.addAdditionalRole(rolename)
         except IndexError as e:
             user = self.bot.owner
-            raise RoleError("Too many additional roles. This should not "
-                            f"happen. Nag at {user.mention}") from e
+            raise RoleError(
+                f"Too many additional roles. This should not happen. Nag at {user.mention}"
+            ) from e
         except RoleError as e:
             if batch:
                 # Adding the latest role failed, saving previously added roles
@@ -463,9 +542,10 @@ class CommandListener(Cog):
             raise e
         await self._update_event(event, reorder=False, export=(not batch))
 
-    @command(aliases=['ar'])
-    async def addrole(self, ctx: Context, event: ArgEvent, *,
-                      rolename: UnquotedStr):
+    @command(aliases=["ar"])
+    async def addrole(
+        self, ctx: Context, event: ArgEvent, *, rolename: UnquotedStr
+    ):
         """
         Add a new additional role or multiple roles to the event.
 
@@ -476,11 +556,11 @@ class CommandListener(Cog):
                  addrole 1 Y1 (Bradley) Driver
                    Y1 (Bradley) Gunner
         """
-        if '\n' in rolename:
+        if "\n" in rolename:
             await ctx.send("Adding roles")
             msg = ""
             try:
-                for role in rolename.split('\n'):
+                for role in rolename.split("\n"):
                     role = role.strip()
                     await self._add_role(event, role, batch=True)
                     msg += f"Role {role} added to event {event}\n"
@@ -498,9 +578,10 @@ class CommandListener(Cog):
         await self._show(ctx, event)
 
     # Remove additional role from event command
-    @command(aliases=['rr'])
-    async def removerole(self, ctx: Context, event: ArgEvent, *,
-                         role: ArgRole):
+    @command(aliases=["rr"])
+    async def removerole(
+        self, ctx: Context, event: ArgEvent, *, role: ArgRole
+    ):
         """
         Remove an additional role from the event.
 
@@ -512,9 +593,15 @@ class CommandListener(Cog):
         await ctx.send(f"Role {role_name} removed from {event}")
         await self._show(ctx, event)
 
-    @command(aliases=['rnr', 'rename'])
-    async def renamerole(self, ctx: Context, event: ArgEvent,
-                         role: ArgRole, *, new_name: UnquotedStr):
+    @command(aliases=["rnr", "rename"])
+    async def renamerole(
+        self,
+        ctx: Context,
+        event: ArgEvent,
+        role: ArgRole,
+        *,
+        new_name: UnquotedStr,
+    ):
         """
         Rename an additional role of the event.
 
@@ -524,13 +611,15 @@ class CommandListener(Cog):
         old_name = role.name
         event.renameAdditionalRole(role, new_name)
         await self._update_event(event, reorder=False)
-        await ctx.send(f"Role renamed. Old name: {old_name}, "
-                       f"new name: {role} @ {event}")
+        await ctx.send(
+            f"Role renamed. Old name: {old_name}, new name: {role} @ {event}"
+        )
         await self._show(ctx, event)
 
-    @command(aliases=['rra'])
-    async def removereaction(self, ctx: Context, event: ArgEvent,
-                             reaction: str):
+    @command(aliases=["rra"])
+    async def removereaction(
+        self, ctx: Context, event: ArgEvent, reaction: str
+    ):
         """
         Removes a role and the corresponding reaction from the event and updates the message.
         """  # NOQA
@@ -547,9 +636,10 @@ class CommandListener(Cog):
                     return
         raise BadArgument("No reaction found")
 
-    @command(aliases=['rg'])
-    async def removegroup(self, ctx: Context, eventMessage: ArgMessage, *,
-                          groupName: UnquotedStr):
+    @command(aliases=["rg"])
+    async def removegroup(
+        self, ctx: Context, eventMessage: ArgMessage, *, groupName: UnquotedStr
+    ):
         """
         Remove a role group from the event.
 
@@ -571,9 +661,10 @@ class CommandListener(Cog):
         await self._show(ctx, event)
 
     # Set title of event command
-    @command(aliases=['stt'])
-    async def settitle(self, ctx: Context, event: ArgEvent, *,
-                       title: UnquotedStr):
+    @command(aliases=["stt"])
+    async def settitle(
+        self, ctx: Context, event: ArgEvent, *, title: UnquotedStr
+    ):
         """
         Set event title.
 
@@ -584,14 +675,16 @@ class CommandListener(Cog):
         # and a bot crash
         event.title = title
         await self._update_event(event)
-        await ctx.send(f"Title {event.title} set for operation "
-                       f"ID {event.id} at {event.date}")
+        await ctx.send(
+            f"Title {event.title} set for operation ID {event.id} at {event.date}"
+        )
         await self._show(ctx, event)
 
     # Set date of event command
-    @command(aliases=['sdt'])
-    async def setdate(self, ctx: Context, event: ArgEvent,
-                      _datetime: ArgDateTime):
+    @command(aliases=["sdt"])
+    async def setdate(
+        self, ctx: Context, event: ArgEvent, _datetime: ArgDateTime
+    ):
         """
         Set event date.
 
@@ -603,14 +696,16 @@ class CommandListener(Cog):
         # Update event and sort events, export
         await msgFnc.sortEventMessages(self.bot)
         EventDatabase.toJson()  # Update JSON file
-        await ctx.send(f"Date {event.date} set for operation "
-                       f"{event.title} ID {event.id}")
+        await ctx.send(
+            f"Date {event.date} set for operation {event.title} ID {event.id}"
+        )
         await self._show(ctx, event)
 
     # Set time of event command
-    @command(aliases=['stm'])
-    async def settime(self, ctx: Context, event: ArgEvent,
-                      event_time: ArgTime):
+    @command(aliases=["stm"])
+    async def settime(
+        self, ctx: Context, event: ArgEvent, event_time: ArgTime
+    ):
         """
         Set event time.
 
@@ -626,9 +721,10 @@ class CommandListener(Cog):
         await self._show(ctx, event)
 
     # Set terrain of event command
-    @command(aliases=['st'])
-    async def setterrain(self, ctx: Context, event: ArgEvent, *,
-                         terrain: UnquotedStr):
+    @command(aliases=["st"])
+    async def setterrain(
+        self, ctx: Context, event: ArgEvent, *, terrain: UnquotedStr
+    ):
         """
         Set event terrain.
 
@@ -641,9 +737,10 @@ class CommandListener(Cog):
         await self._show(ctx, event)
 
     # Set faction of event command
-    @command(aliases=['sf'])
-    async def setfaction(self, ctx: Context, event: ArgEvent, *,
-                         faction: UnquotedStr):
+    @command(aliases=["sf"])
+    async def setfaction(
+        self, ctx: Context, event: ArgEvent, *, faction: UnquotedStr
+    ):
         """
         Set event faction.
 
@@ -655,21 +752,28 @@ class CommandListener(Cog):
         await ctx.send(f"Faction {event.faction} set for operation {event}")
         await self._show(ctx, event)
 
-    async def _set_description(self, ctx: Context, event: Event,
-                               description: str = ""):
+    async def _set_description(
+        self, ctx: Context, event: Event, description: str = ""
+    ):
         # Change description, update event
         event.description = description
         await self._update_event(event)
         if description:
-            await ctx.send(f"Description \"{event.description}\" "
-                           f"set for operation {event}")
+            await ctx.send(
+                f'Description "{event.description}" set for operation {event}'
+            )
             await self._show(ctx, event)
         else:
             await ctx.send(f"Description cleared from operation {event}")
 
-    @command(aliases=['sd'])
-    async def setdescription(self, ctx: Context, event: ArgEvent, *,
-                             description: UnquotedStr = ""):  # type: ignore
+    @command(aliases=["sd"])
+    async def setdescription(
+        self,
+        ctx: Context,
+        event: ArgEvent,
+        *,
+        description: UnquotedStr = "",  # type: ignore
+    ):
         """
         Set or clear event description. To clear the description, run `setdescription [ID]` without the description parameter
 
@@ -677,7 +781,7 @@ class CommandListener(Cog):
         """  # NOQA
         await self._set_description(ctx, event, description)
 
-    @command(aliases=['cld'])
+    @command(aliases=["cld"])
     async def cleardescription(self, ctx: Context, event: ArgEvent):
         """
         Clear event description. Alias for `setdescription [ID]`
@@ -686,19 +790,21 @@ class CommandListener(Cog):
         """
         await self._set_description(ctx, event)
 
-    async def _set_port(self, ctx: Context, event: Event,
-                        port: int = cfg.PORT_DEFAULT):
+    async def _set_port(
+        self, ctx: Context, event: Event, port: int = cfg.PORT_DEFAULT
+    ):
         event.port = port
         await self._update_event(event)
         if port != cfg.PORT_DEFAULT:
-            await ctx.send(f"Port \"{event.port}\" set for operation {event}")
+            await ctx.send(f'Port "{event.port}" set for operation {event}')
             await self._show(ctx, event)
         else:
             await ctx.send(f"Default port set for operation {event}")
 
-    @command(aliases=['sp'])
-    async def setport(self, ctx: Context, event: ArgEvent,
-                      port: int = cfg.PORT_DEFAULT):
+    @command(aliases=["sp"])
+    async def setport(
+        self, ctx: Context, event: ArgEvent, port: int = cfg.PORT_DEFAULT
+    ):
         """
         Set or clear event server port. To clear the port, run `setport [ID]` without the port parameter
 
@@ -706,7 +812,7 @@ class CommandListener(Cog):
         """  # NOQA
         await self._set_port(ctx, event, port)
 
-    @command(aliases=['clp'])
+    @command(aliases=["clp"])
     async def clearport(self, ctx: Context, event: ArgEvent):
         """
         Clear event port. Alias for `setport [ID]`
@@ -715,22 +821,27 @@ class CommandListener(Cog):
         """
         await self._set_port(ctx, event)
 
-    async def _set_mods(self, ctx: Context, event: Event,
-                        mods: str = ""):
+    async def _set_mods(self, ctx: Context, event: Event, mods: str = ""):
         event.mods = mods
         await self._update_event(event)
         if mods:
-            await ctx.send(f"Mods ```\n{event.mods}\n``` "
-                           f"set for operation {event}")
+            await ctx.send(
+                f"Mods ```\n{event.mods}\n``` set for operation {event}"
+            )
             await self._set_port(ctx, event, cfg.PORT_MODDED)
             await self._show(ctx, event)
         else:
             await ctx.send(f"Mods cleared from operation {event}")
             await self._set_port(ctx, event, cfg.PORT_DEFAULT)
 
-    @command(aliases=['sm', 'setmod'])
-    async def setmods(self, ctx: Context, event: ArgEvent,
-                      *, mods: UnquotedStr = ""):  # type: ignore
+    @command(aliases=["sm", "setmod"])
+    async def setmods(
+        self,
+        ctx: Context,
+        event: ArgEvent,
+        *,
+        mods: UnquotedStr = "",  # type: ignore
+    ):
         """
         Set or clear event server mods.
 
@@ -743,7 +854,7 @@ class CommandListener(Cog):
         """  # NOQA
         await self._set_mods(ctx, event, mods)
 
-    @command(aliases=['clm', 'clearmod'])
+    @command(aliases=["clm", "clearmod"])
     async def clearmods(self, ctx: Context, event: ArgEvent):
         """
         Clear event mods. Alias for `setmods [ID]`
@@ -752,14 +863,22 @@ class CommandListener(Cog):
         """
         await self._set_mods(ctx, event)
 
-    async def _set_quick(self, ctx: Context, event: Event, terrain: str,
-                         faction: str, zeus: Member = None,
-                         _time: ArgTime = None, quiet=False):
+    async def _set_quick(
+        self,
+        ctx: Context,
+        event: Event,
+        terrain: str,
+        faction: str,
+        zeus: Member = None,
+        _time: ArgTime = None,
+        quiet=False,
+    ):
         event.terrain = terrain
         event.faction = faction
         if zeus is not None:
-            event.signup(event.findRoleWithName(cfg.EMOJI_ZEUS), zeus,
-                         replace=True)
+            event.signup(
+                event.findRoleWithName(cfg.EMOJI_ZEUS), zeus, replace=True
+            )
         if _time is not None:
             event.time = _time
 
@@ -770,10 +889,16 @@ class CommandListener(Cog):
             await ctx.send(f"Updated event {event}{msg_zeus}")
             await self._show(ctx, event)
 
-    @command(aliases=['sq'])
-    async def setquick(self, ctx: Context, event: ArgEvent,
-                       terrain: str, faction: str, zeus: ArgMember = None,
-                       _time: ArgTime = None):
+    @command(aliases=["sq"])
+    async def setquick(
+        self,
+        ctx: Context,
+        event: ArgEvent,
+        terrain: str,
+        faction: str,
+        zeus: ArgMember = None,
+        _time: ArgTime = None,
+    ):
         """
         Quickly set event details.
 
@@ -783,13 +908,13 @@ class CommandListener(Cog):
                  setquick 1 Altis USMC Stroker
                  setquick 1 Altis USMC Stroker 17:30
         """  # NOQA
-        await self._set_quick(ctx, event, terrain,
-                              faction, zeus, _time)
+        await self._set_quick(ctx, event, terrain, faction, zeus, _time)
 
     # Sign user up to event command
-    @command(aliases=['s'])
-    async def signup(self, ctx: Context, event: ArgEvent, user: ArgMember, *,
-                     role: ArgRole):
+    @command(aliases=["s"])
+    async def signup(
+        self, ctx: Context, event: ArgEvent, user: ArgMember, *, role: ArgRole
+    ):
         """
         Sign user up to a role.
 
@@ -803,8 +928,7 @@ class CommandListener(Cog):
         # Sign user up, update event, export
         old_signup, replaced_user = event.signup(role, user, replace=True)
         await self._update_event(event)
-        message = (f"User {user.display_name} signed up to event "
-                   f"{event} as {role.name}")
+        message = f"User {user.display_name} signed up to event {event} as {role.name}"
         if old_signup:
             # User was signed on to a different role previously
             message += f". Signed off from {old_signup.name}"
@@ -815,9 +939,10 @@ class CommandListener(Cog):
         await self._show(ctx, event)
 
     # Remove signup on event of user command
-    @command(aliases=['rs'])
-    async def removesignup(self, ctx: Context, event: ArgEvent,
-                           user: ArgMember):
+    @command(aliases=["rs"])
+    async def removesignup(
+        self, ctx: Context, event: ArgEvent, user: ArgMember
+    ):
         """
         Undo user signup (manually).
 
@@ -829,15 +954,17 @@ class CommandListener(Cog):
         role: Optional[Role] = event.undoSignup(user)
         if role:
             await self._update_event(event)
-            await ctx.send(f"User {user.display_name} removed from role "
-                           f"{role.display_name} in event {event}")
+            await ctx.send(
+                f"User {user.display_name} removed from role {role.display_name} in event {event}"
+            )
             await self._show(ctx, event)
         else:
-            await ctx.send(f"No signup to remove for user {user.display_name} "
-                           f"in event {event}")
+            await ctx.send(
+                f"No signup to remove for user {user.display_name} in event {event}"
+            )
 
     # Archive event command
-    @command(aliases=['a'])
+    @command(aliases=["a"])
     async def archive(self, ctx: Context, event: ArgEvent):
         """
         Archive event.
@@ -850,8 +977,9 @@ class CommandListener(Cog):
         try:
             eventMessage = await msgFnc.getEventMessage(event, self.bot)
         except MessageNotFound:
-            await ctx.send(f"Internal error: event {event} without "
-                           "a message found")
+            await ctx.send(
+                f"Internal error: event {event} without a message found"
+            )
         else:
             await eventMessage.delete()
 
@@ -865,7 +993,8 @@ class CommandListener(Cog):
         EventDatabase.removeEvent(event.id, archived=archived)
         try:
             eventMessage = await msgFnc.getEventMessage(
-                event, self.bot, archived=archived)
+                event, self.bot, archived=archived
+            )
         except MessageNotFound:
             # Message already deleted, nothing to be done
             pass
@@ -874,7 +1003,7 @@ class CommandListener(Cog):
         EventDatabase.toJson(archive=archived)
 
     # Delete event command
-    @command(aliases=['d'])
+    @command(aliases=["d"])
     async def delete(self, ctx: Context, event: ArgEvent):
         """
         Delete event.
@@ -929,8 +1058,7 @@ class CommandListener(Cog):
         await ctx.send(f"{len(EventDatabase.events)} events imported")
 
     @command()
-    async def dump(self, ctx: Context, event: ArgEvent,
-                   roleGroup: str = None):
+    async def dump(self, ctx: Context, event: ArgEvent, roleGroup: str = None):
         """Dump given event as YAML for mass editing.
 
         Use `load` to import the data back in after editing. Specify roleGroup
@@ -970,22 +1098,28 @@ class CommandListener(Cog):
         # help messages
         if ctx.guild is None:
             raise CommandError("This command can only be used in a server")
-        await self._load(ctx, event, data, ctx.guild.emojis,
-                         cast(TextChannel, ctx.channel))
+        await self._load(
+            ctx, event, data, ctx.guild.emojis, cast(TextChannel, ctx.channel)
+        )
         await ctx.send("Event data loaded")
 
-    async def _load(self, _: Context, event: Event, data: str,
-                    emojis: Tuple[Emoji, ...], target: TextChannel = None):
-        if data.startswith('```') and data.endswith('```'):
+    async def _load(
+        self,
+        _: Context,
+        event: Event,
+        data: str,
+        emojis: Tuple[Emoji, ...],
+        target: TextChannel = None,
+    ):
+        if data.startswith("```") and data.endswith("```"):
             # Remove the first line (containing ```yaml) and the last three
             # characters (containing ```)
-            data = data.strip()[3:-3].split('\n', 1)[1].strip()
+            data = data.strip()[3:-3].split("\n", 1)[1].strip()
         loaded_data = yaml.safe_load(data)
-        if 'roleGroups' in loaded_data:
-            event.fromJson(event.id, loaded_data, emojis,
-                           manual_load=True)
-        elif 'roles' in loaded_data:
-            groupName = loaded_data['name']
+        if "roleGroups" in loaded_data:
+            event.fromJson(event.id, loaded_data, emojis, manual_load=True)
+        elif "roles" in loaded_data:
+            groupName = loaded_data["name"]
             roleGroup: RoleGroup = event.getRoleGroup(groupName)
             roleGroup.fromJson(loaded_data, emojis, manual_load=True)
         else:
@@ -1003,8 +1137,9 @@ class CommandListener(Cog):
     #     EventDatabase.toJson()
     #     await ctx.send("Event messages created")
 
-    async def _update_event(self, event: Event, import_db=False,
-                            reorder=True, export=True):
+    async def _update_event(
+        self, event: Event, import_db=False, reorder=True, export=True
+    ):
         # TODO: Move to a more appropriate location
         if import_db:
             await self.bot.import_database()
@@ -1014,24 +1149,28 @@ class CommandListener(Cog):
         try:
             message = await msgFnc.getEventMessage(event, self.bot)
         except MessageNotFound:
-            message = await msgFnc.createEventMessage(event,
-                                                      self.bot.eventchannel)
+            message = await msgFnc.createEventMessage(
+                event, self.bot.eventchannel
+            )
 
-        await msgFnc.updateMessageEmbed(eventMessage=message,
-                                        updatedEvent=event)
-        await msgFnc.updateReactions(event=event, message=message,
-                                     reorder=reorder)
+        await msgFnc.updateMessageEmbed(
+            eventMessage=message, updatedEvent=event
+        )
+        await msgFnc.updateReactions(
+            event=event, message=message, reorder=reorder
+        )
         if export:
             EventDatabase.toJson()
 
-    @command(aliases=['upde'])
-    async def updateevent(self, ctx: Context, event: ArgEvent,
-                          import_db: bool = False):
+    @command(aliases=["upde"])
+    async def updateevent(
+        self, ctx: Context, event: ArgEvent, import_db: bool = False
+    ):
         """Import database, update embed and reactions on a single event message."""  # NOQA
         await self._update_event(event, import_db=import_db)
         await ctx.send("Event updated")
 
-    @command(aliases=['syncm'])
+    @command(aliases=["syncm"])
     async def syncmessages(self, ctx: Context):
         """Import database, sync messages with events and create missing messages."""  # NOQA
         await self.bot.import_database()
@@ -1057,36 +1196,51 @@ class CommandListener(Cog):
             await ctx.send(f"Missing argument. See: `{CMD}help {ctx.command}`")
             return
         elif isinstance(error, BadArgument):
-            await ctx.send(f"Invalid argument: {error}. "
-                           f"See: `{CMD}help {ctx.command}`")
+            await ctx.send(
+                f"Invalid argument: {error}. See: `{CMD}help {ctx.command}`"
+            )
             return
         elif isinstance(error, CommandInvokeError):
             if isinstance(error.original, UnexpectedRole):
-                await ctx.send(f"Malformed data: {error.original}. "
-                               f"See: `{CMD}help {ctx.command}`")
+                await ctx.send(
+                    f"Malformed data: {error.original}. See: `{CMD}help {ctx.command}`"
+                )
                 return
             elif isinstance(error.original, RoleError):
-                await ctx.send(f"An error occured: ```{error.original}```\n"
-                               f"Message: `{ctx.message.clean_content}`")
+                await ctx.send(
+                    f"An error occured: ```{error.original}```\n"
+                    f"Message: `{ctx.message.clean_content}`"
+                )
                 return
             else:
                 error = error.original
-        print(''.join(traceback.format_exception(type(error),
-              error, error.__traceback__)))
-        trace = ''.join(traceback.format_exception(type(error), error,
-                        error.__traceback__, 2))
+        print(
+            "".join(
+                traceback.format_exception(
+                    type(error), error, error.__traceback__
+                )
+            )
+        )
+        trace = "".join(
+            traceback.format_exception(
+                type(error), error, error.__traceback__, 2
+            )
+        )
 
-        messages = ctx.message.clean_content.split('\n')
+        messages = ctx.message.clean_content.split("\n")
         if len(messages) >= 1:
             # Show only first line of the message
             message = f"{messages[0]} [...]"
         else:
             message = messages[0]
-        msg = (f"Unexpected error occured: ```{error}```\n"
-               f"Message: `{message}`\n\n```py\n{trace}```")
+        msg = (
+            f"Unexpected error occured: ```{error}```\n"
+            f"Message: `{message}`\n\n```py\n{trace}```"
+        )
         if len(msg) >= 2000:
-            await ctx.send("Received error message that's over 2000 "
-                           "characters, check log.")
+            await ctx.send(
+                "Received error message that's over 2000 characters, check log."
+            )
             print("Message:", ctx.message.clean_content)
         else:
             await ctx.send(msg)

--- a/src/operationbot/config.py
+++ b/src/operationbot/config.py
@@ -12,19 +12,19 @@ if secret.DEBUG:
     EVENT_ARCHIVE_CHANNEL = _test_channel
     COMMAND_CHANNEL = _test_channel
     LOG_CHANNEL = _test_channel
-    GAME = 'with bugs'
+    GAME = "with bugs"
     EMOJI_GUILD = 219564389462704130
 else:
     EVENT_CHANNEL = 502824760036818964
     EVENT_ARCHIVE_CHANNEL = 528914471700267029
     COMMAND_CHANNEL = 528980590930821131
     LOG_CHANNEL = 621066917339201547
-    GAME = 'with events'
+    GAME = "with events"
     # If set to 0, the bot uses Command Channel's guild
     EMOJI_GUILD = 0
 
 JSON_FILEPATH = {
-    "events":  "database/events.json",
+    "events": "database/events.json",
     "archive": "database/archive.json",
 }
 ADDITIONAL_ROLE_EMOJIS = [
@@ -89,7 +89,7 @@ SPECIAL_EMOJIS: List[str] = [
     ATTENDANCE_EMOJI,
 ]
 
-PLATOON_SIZES = ['1PLT', '2PLT', 'sideop', 'WW2side']
+PLATOON_SIZES = ["1PLT", "2PLT", "sideop", "WW2side"]
 
 # Dummy: an empty spacer. An embed can only have either one or three
 # items on a line.
@@ -99,23 +99,23 @@ DEFAULT_GROUPS: Dict[str, List[str]] = {
         "Company",
         "1st Platoon",
         "Dummy",
-
+        #
         "Alpha",
         "Bravo",
-        "Charlie"
+        "Charlie",
     ],
     "2PLT": [
         "Battalion",
         "Company",
         "Dummy",
-
+        #
         "1st Platoon",
         "Alpha",
         "Bravo",
-
+        #
         "2nd Platoon",
         "Echo",
-        "Foxtrot"
+        "Foxtrot",
     ],
     "sideop": [
         "Company",
@@ -135,7 +135,7 @@ DEFAULT_ROLES: Dict[str, Dict] = {
         "1PLT": "1st Platoon",
         "FAC": "1st Platoon",
         "RTO": "1st Platoon",
-
+        #
         "ASL": "Alpha",
         "A1": "Alpha",
         "A2": "Alpha",
@@ -151,7 +151,7 @@ DEFAULT_ROLES: Dict[str, Dict] = {
         "CO": "Company",
         "FAC": "Company",
         "RTO": "Company",
-
+        #
         "1PLT": "1st Platoon",
         "ASL": "Alpha",
         "A1": "Alpha",
@@ -161,7 +161,7 @@ DEFAULT_ROLES: Dict[str, Dict] = {
         "C1": "Charlie",
         "DSL": "Delta",
         "D1": "Delta",
-
+        #
         "2PLT": "2nd Platoon",
         "ESL": "Echo",
         "E1": "Echo",
@@ -195,12 +195,27 @@ EMOJI_ZEUS = "ZEUS"
 SIGNOFF_NOTIFY_TIME = timedelta(days=1)
 SIGNOFF_NOTIFY_ROLES: Dict[str, List] = {
     "1PLT": [
-        "1PLT", "HQ", "ASL", "BSL", "CSL"
+        "1PLT",
+        "HQ",
+        "ASL",
+        "BSL",
+        "CSL",
     ],
     "2PLT": [
-        "CO", "HQ", "1PLT", "2PLT",
-        "ASL", "BSL", "CSL", "DSL",
-        "ESL", "FSL", "GSL", "HSL",
+        "CO",
+        "HQ",
+        "1PLT",
+        "2PLT",
+        #
+        "ASL",
+        "BSL",
+        "CSL",
+        "DSL",
+        #
+        "ESL",
+        "FSL",
+        "GSL",
+        "HSL",
     ],
     "sideop": [],
     "WW2side": [],
@@ -221,5 +236,5 @@ EMBED_COLOR = {
 
 DLC_TERRAINS = {
     "Tanoa": "APEX",
-    "Livonia": "Contact"
+    "Livonia": "Contact",
 }

--- a/src/operationbot/converters.py
+++ b/src/operationbot/converters.py
@@ -5,8 +5,11 @@ from typing import cast
 from discord import Member, Message
 from discord.ext.commands.context import Context
 from discord.ext.commands.converter import MemberConverter
-from discord.ext.commands.errors import (BadArgument, CommandError,
-                                         MemberNotFound)
+from discord.ext.commands.errors import (
+    BadArgument,
+    CommandError,
+    MemberNotFound,
+)
 
 from operationbot import config as cfg
 from operationbot import messageFunctions as msgFnc
@@ -40,13 +43,11 @@ def _get_index(argument: str) -> int:
         # Argument might already be a numeral
         pass
     except KeyError as e:
-        raise ValueError(f"{argument} is not a number or a numeral.") \
-            from e
+        raise ValueError(f"{argument} is not a number or a numeral.") from e
     try:
         return cfg.ADDITIONAL_ROLE_NAMES.index(argument)
     except ValueError as e:
-        raise ValueError(f"{argument} is not a number or a numeral.") \
-            from e
+        raise ValueError(f"{argument} is not a number or a numeral.") from e
 
 
 class ArgRole(Role):
@@ -64,12 +65,13 @@ class ArgRole(Role):
 
     Finally, raises a BadArgument if no role was found.
     """
+
     # NOTE: the third chapter of the docstring (Converts the following [..]) is
     # dynamically parsed and displayed as a part of the `roleparserinfo`
     # command. If the structure of the docstring is changed, the command must
     # be ajusted accordingly.
 
-    EMOJI_PATTERN = r'<a?:([a-zA-Z0-9_])+:[0-9]+>'
+    EMOJI_PATTERN = r"<a?:([a-zA-Z0-9_])+:[0-9]+>"
 
     @classmethod
     async def convert(cls, ctx: Context, argument: str) -> Role:
@@ -78,12 +80,13 @@ class ArgRole(Role):
             event: Event = ctx.args[2]
             assert isinstance(event, Event)
         except (IndexError, AssertionError) as e:
-            raise CommandError(f"The command {ctx.command} is invalid. "
-                               "The ArgRole converter requires an Event to be "
-                               "the first argument of the calling command") \
-                from e
+            raise CommandError(
+                f"The command {ctx.command} is invalid. "
+                "The ArgRole converter requires an Event to be "
+                "the first argument of the calling command"
+            ) from e
         additional = event.getRoleGroup("Additional")
-        first_arg = argument.split(' ')[0]
+        first_arg = argument.split(" ")[0]
         try:
             index = _get_index(first_arg)
         except ValueError:
@@ -118,8 +121,12 @@ class UnquotedStr(str):
 
     @classmethod
     def unquote(cls, argument: str) -> str:
-        if (argument.startswith('"') and argument.endswith('"')
-                or argument.startswith("'") and argument.endswith("'")):
+        if (
+            argument.startswith('"')
+            and argument.endswith('"')
+            or argument.startswith("'")
+            and argument.endswith("'")
+        ):
             return argument[1:-1]
         return argument
 
@@ -134,8 +141,9 @@ class ArgEvent(Event):
         try:
             event_id = int(arg)
         except ValueError as e:
-            raise BadArgument(f"Invalid message ID {arg}, needs to be an "
-                              "integer") from e
+            raise BadArgument(
+                f"Invalid message ID {arg}, needs to be an integer"
+            ) from e
 
         try:
             if not archived:
@@ -167,21 +175,23 @@ class ArgDate(date):
         try:
             return date.fromisoformat(arg)
         except ValueError as e:
-            raise BadArgument(f"Invalid date format {arg}. "
-                              "Has to be YYYY-MM-DD") from e
+            raise BadArgument(
+                f"Invalid date format {arg}. Has to be YYYY-MM-DD"
+            ) from e
 
 
 class ArgTime(time):
     @classmethod
     async def convert(cls, _: Context, arg: str) -> time:
-        for fmt in ('%H:%M', '%H%M'):
+        for fmt in ("%H:%M", "%H%M"):
             try:
                 _date = datetime.strptime(arg, fmt)
                 return time(_date.hour, _date.minute)
             except ValueError:
                 pass
-        raise BadArgument(f"Invalid time format {arg}. "
-                          "Has to be HH:MM or HHMM")
+        raise BadArgument(
+            f"Invalid time format {arg}. Has to be HH:MM or HHMM"
+        )
 
 
 class ArgMessage(Message):
@@ -190,12 +200,14 @@ class ArgMessage(Message):
         try:
             event_id = int(arg)
         except ValueError as e:
-            raise BadArgument(f"Invalid message ID {arg}, needs to be an "
-                              "integer") from e
+            raise BadArgument(
+                f"Invalid message ID {arg}, needs to be an integer"
+            ) from e
         try:
             event = EventDatabase.getEventByID(event_id)
             message = await msgFnc.getEventMessage(
-                event, cast(OperationBot, ctx.bot))
+                event, cast(OperationBot, ctx.bot)
+            )
         except (EventNotFound, MessageNotFound) as e:
             raise BadArgument(str(e)) from e
 
@@ -211,8 +223,9 @@ class ArgMember(Member):
             return await converter.convert(ctx, argument)
         except MemberNotFound:
             pass
-        name_regex = re.compile(f'^([A-Z]\\. )?{argument}( \\(.+/.+\\))?$'
-                                .lower())
+        name_regex = re.compile(
+            f"^([A-Z]\\. )?{argument}( \\(.+/.+\\))?$".lower()
+        )
         guild = ctx.guild
         if guild is not None:
             for member in guild.members:

--- a/src/operationbot/converters.py
+++ b/src/operationbot/converters.py
@@ -13,10 +13,10 @@ from discord.ext.commands.errors import (
 
 from operationbot import config as cfg
 from operationbot import messageFunctions as msgFnc
+from operationbot.bot import OperationBot
 from operationbot.errors import EventNotFound, MessageNotFound, RoleNotFound
 from operationbot.event import Event
 from operationbot.eventDatabase import EventDatabase
-from operationbot.bot import OperationBot
 from operationbot.role import Role
 
 NUMBERS = {
@@ -78,7 +78,8 @@ class ArgRole(Role):
         argument = UnquotedStr.unquote(argument)
         try:
             event: Event = ctx.args[2]
-            assert isinstance(event, Event)
+            if not isinstance(event, Event):
+                raise ValueError
         except (IndexError, AssertionError) as e:
             raise CommandError(
                 f"The command {ctx.command} is invalid. "

--- a/src/operationbot/event.py
+++ b/src/operationbot/event.py
@@ -7,7 +7,12 @@ from discord import Embed, Emoji
 from operationbot import config as cfg
 from operationbot.additional_role_group import AdditionalRoleGroup
 from operationbot.config import EMBED_COLOR
-from operationbot.errors import RoleError, RoleGroupNotFound, RoleNotFound, RoleTaken
+from operationbot.errors import (
+    RoleError,
+    RoleGroupNotFound,
+    RoleNotFound,
+    RoleTaken,
+)
 from operationbot.role import Role
 from operationbot.roleGroup import RoleGroup
 from operationbot.secret import PLATOON_SIZE
@@ -30,7 +35,7 @@ class User:
         self.id = id
         self.display_name = display_name
 
-    def __eq__(self, other: Union['User', discord.abc.User]):  # type: ignore
+    def __eq__(self, other: Union["User", discord.abc.User]):  # type: ignore
         # This makes it so that User objects can be compared to
         # discord.abc.User by doing `user == discord.abc.User`. The comparison
         # will not work in the other direction because discord.abc.User checks
@@ -39,9 +44,15 @@ class User:
 
 
 class Event:
-
-    def __init__(self, date: datetime.datetime, guildEmojis: Tuple[Emoji, ...],
-                 eventID=0, importing=False, sideop=False, platoon_size=None):
+    def __init__(
+        self,
+        date: datetime.datetime,
+        guildEmojis: Tuple[Emoji, ...],
+        eventID=0,
+        importing=False,
+        sideop=False,
+        platoon_size=None,
+    ):
         self._title: Optional[str] = None
         self.date = date
         self._terrain = TERRAIN
@@ -81,12 +92,12 @@ class Event:
     @property
     def color(self) -> int:
         if self.dlc and self.sideop:
-            return EMBED_COLOR['DLC_SIDEOP']
+            return EMBED_COLOR["DLC_SIDEOP"]
         if self.dlc:
-            return EMBED_COLOR['DLC']
+            return EMBED_COLOR["DLC"]
         if self.sideop:
-            return EMBED_COLOR['SIDEOP']
-        return EMBED_COLOR['DEFAULT']
+            return EMBED_COLOR["SIDEOP"]
+        return EMBED_COLOR["DEFAULT"]
 
     @property
     def title(self) -> str:
@@ -121,19 +132,23 @@ class Event:
             print("sourcegroup", type(sourceGroup), sourceGroup.name)
             msg = ""
             role = sourceGroup[roleName]
-            print(f"moving role {roleName} from {sourceGroup.name} to "
-                  f"{targetGroupName}")
+            print(
+                f"moving role {roleName} from {sourceGroup.name} to {targetGroupName}"
+            )
             if targetGroupName is None:
                 if role.userID is not None:
-                    msg = (f"Warning: removing an active role {role} "
-                           f"from {sourceGroup.name}, {self}")
+                    msg = (
+                        f"Warning: removing an active role {role} "
+                        f"from {sourceGroup.name}, {self}"
+                    )
                     print("removing active role")
                 sourceGroup.removeRole(roleName)
             else:
                 if targetGroupName not in self.roleGroups:
                     print("creating target group")
-                    self.roleGroups[targetGroupName] = \
-                        RoleGroup(targetGroupName)
+                    self.roleGroups[targetGroupName] = RoleGroup(
+                        targetGroupName
+                    )
                 self.roleGroups[targetGroupName][roleName] = role
                 self.roleGroups[sourceGroup.name].removeRole(roleName)
             if not self.roleGroups[sourceGroup.name]:
@@ -157,26 +172,25 @@ class Event:
                 msg = _moveRole("ZEUS", sourceGroup, "Company")
                 if msg != "":
                     print(msg)
-                    warnings += msg + '\n'
+                    warnings += msg + "\n"
 
                 sourceGroup = self.roleGroups["Company"]
                 for roleName in ["FAC", "RTO"]:
-                    msg = _moveRole(roleName, sourceGroup,
-                                    "1st Platoon")
+                    msg = _moveRole(roleName, sourceGroup, "1st Platoon")
                     if msg != "":
                         print(msg)
-                        warnings += msg + '\n'
+                        warnings += msg + "\n"
                 sourceGroup = self.roleGroups["Company"]
                 msg = _moveRole("CO", sourceGroup, None)
                 if msg != "":
                     print(msg)
-                    warnings += msg + '\n'
+                    warnings += msg + "\n"
 
                 sourceGroup = self.roleGroups["2nd Platoon"]
                 msg = _moveRole("2PLT", self.roleGroups["2nd Platoon"], None)
                 if msg != "":
                     print(msg)
-                    warnings += msg + '\n'
+                    warnings += msg + "\n"
 
                 targetGroup = _getTargetGroup(new_groups)
                 sourceGroupName = "Echo"
@@ -185,7 +199,7 @@ class Event:
                     msg = _moveRole(roleName, sourceGroup, targetGroup)
                     if msg != "":
                         print(msg)
-                        warnings += msg + '\n'
+                        warnings += msg + "\n"
 
                 targetGroup = _getTargetGroup(new_groups)
                 sourceGroupName = "Foxtrot"
@@ -199,7 +213,7 @@ class Event:
                     for roleName in ["FSL", "F1"]:
                         msg = _moveRole(roleName, sourceGroup, targetGroup)
                         print(msg)
-                        warnings += msg + '\n'
+                        warnings += msg + "\n"
                 else:
                     del self.roleGroups[sourceGroupName]
 
@@ -216,18 +230,23 @@ class Event:
                 self.platoon_size = "1PLT"
 
             else:
-                raise ValueError("Unsupported platoon size conversion: "
-                                 f"{self.platoon_size} -> {new_size}")
+                raise ValueError(
+                    "Unsupported platoon size conversion: "
+                    "{self.platoon_size} -> {new_size}"
+                )
         elif self.platoon_size == "1PLT":
             if new_size == "2PLT":
                 # TODO: implement 1PLT -> 2PLT conversion
-                raise NotImplementedError("Conversion from 1PLT to 2PLT "
-                                          "not implemented")
-            raise ValueError("Unsupported platoon size conversion: "
-                             f"{self.platoon_size} -> {new_size}")
+                raise NotImplementedError(
+                    "Conversion from 1PLT to 2PLT not implemented"
+                )
+            raise ValueError(
+                "Unsupported platoon size conversion: {self.platoon_size} -> {new_size}"
+            )
         else:
-            raise ValueError("Unsupported current platoon size: "
-                             f"{self.platoon_size}")
+            raise ValueError(
+                f"Unsupported current platoon size: {self.platoon_size}"
+            )
         return warnings
 
     def reorder(self):
@@ -236,15 +255,16 @@ class Event:
 
         newGroups = {}
         warnings = ""
-        for groupName in cfg.DEFAULT_GROUPS[self.platoon_size] + \
-                ["Additional"]:
+        for groupName in cfg.DEFAULT_GROUPS[self.platoon_size] + [
+            "Additional"
+        ]:
             try:
                 group = self.roleGroups[groupName]
             except KeyError:
                 group = RoleGroup("Dummy")
                 msg = f"Could not find group {groupName}"
                 print(msg)
-                warnings += msg + '\n'
+                warnings += msg + "\n"
             newGroups[groupName] = group
         self.roleGroups = newGroups
         return warnings
@@ -257,38 +277,50 @@ class Event:
         timestamp = int(date_tz.astimezone(datetime.timezone.utc).timestamp())
         local_time = f"<t:{timestamp}>"
         relative_time = f"<t:{timestamp}:R>"
-        server_port = (f"\nServer port: **{self.port}**"
-                       if self.port != cfg.PORT_DEFAULT else "")
-        dlc_note = (f"\n\nThe **{self.dlc} DLC** is required to "
-                    "join this event"
-                    if self.dlc else "")
-        event_description = (f"\n\n{self.description}"
-                             if self.description else "")
+        server_port = (
+            f"\nServer port: **{self.port}**"
+            if self.port != cfg.PORT_DEFAULT
+            else ""
+        )
+        dlc_note = (
+            f"\n\nThe **{self.dlc} DLC** is required to join this event"
+            if self.dlc
+            else ""
+        )
+        event_description = (
+            f"\n\n{self.description}" if self.description else ""
+        )
         if self.mods:
-            if '\n' in self.mods:
+            if "\n" in self.mods:
                 mods = f"\n\nMods:\n{self.mods}\n"
             else:
                 mods = f"\n\nMods: {self.mods}\n"
         else:
             mods = ""
-        description = (f"Local time: {local_time} ({relative_time})\n"
-                       f"Terrain: {self.terrain} - Faction: {self.faction}"
-                       f"{server_port}"
-                       f"{dlc_note}"
-                       f"{event_description}"
-                       f"{mods}")
-        eventEmbed = Embed(title=title, description=description,
-                           colour=self.color)
+        description = (
+            f"Local time: {local_time} ({relative_time})\n"
+            f"Terrain: {self.terrain} - Faction: {self.faction}"
+            f"{server_port}"
+            f"{dlc_note}"
+            f"{event_description}"
+            f"{mods}"
+        )
+        eventEmbed = Embed(
+            title=title, description=description, colour=self.color
+        )
 
         # Add field to embed for every rolegroup
         for group in self.roleGroups.values():
             if len(group.roles) > 0:
-                eventEmbed.add_field(name=group.name, value=str(group),
-                                     inline=group.isInline)
+                eventEmbed.add_field(
+                    name=group.name, value=str(group), inline=group.isInline
+                )
             elif group.name == "Dummy":
-                eventEmbed.add_field(name="\N{ZERO WIDTH SPACE}",
-                                     value="\N{ZERO WIDTH SPACE}",
-                                     inline=group.isInline)
+                eventEmbed.add_field(
+                    name="\N{ZERO WIDTH SPACE}",
+                    value="\N{ZERO WIDTH SPACE}",
+                    inline=group.isInline,
+                )
 
         if self.sideop or cfg.ALWAYS_DISPLAY_ATTENDANCE:
             attendees = f"Attendees: {len(self.attendees)}\n\n"
@@ -321,8 +353,9 @@ class Event:
             role: Role
             for role in roleGroup.roles:
                 if role.name == name:
-                    raise RoleError(f"Role with name {name} already exists, "
-                                    "not adding new role")
+                    raise RoleError(
+                        f"Role with name {name} already exists, not adding new role"
+                    )
 
         # Find next emoji for additional role
         if self.countReactions() >= MAX_REACTIONS:
@@ -386,8 +419,9 @@ class Event:
         self._terrain = terrain
 
     # Get emojis for normal roles
-    def _getNormalEmojis(self, guildEmojis: Tuple[Emoji, ...]) \
-            -> Dict[str, Emoji]:
+    def _getNormalEmojis(
+        self, guildEmojis: Tuple[Emoji, ...]
+    ) -> Dict[str, Emoji]:
         normalEmojis = {}
 
         for emoji in guildEmojis:
@@ -406,8 +440,9 @@ class Event:
                 emoji = role.emoji
                 # Skip the ZEUS reaction. Zeuses can only be signed up using
                 # the signup command
-                if not (isinstance(emoji, Emoji)
-                        and emoji.name == cfg.EMOJI_ZEUS):
+                if not (
+                    isinstance(emoji, Emoji) and emoji.name == cfg.EMOJI_ZEUS
+                ):
                     reactions.append(role.emoji)
 
         if self.sideop or cfg.ALWAYS_DISPLAY_ATTENDANCE:
@@ -454,8 +489,9 @@ class Event:
         try:
             return self.roleGroups[groupName]
         except KeyError as e:
-            raise RoleGroupNotFound("No role group found with name "
-                                    f"{groupName}") from e
+            raise RoleGroupNotFound(
+                f"No role group found with name {groupName}"
+            ) from e
 
     def hasRoleGroup(self, groupName: str) -> bool:
         """Check if a role group with given name exists in the event."""
@@ -464,8 +500,9 @@ class Event:
     def get_additional_role(self, role_name: str) -> Role:
         return self.roleGroups["Additional"][role_name]
 
-    def signup(self, roleToSet: Role, user: discord.abc.User, replace=False) \
-            -> Tuple[Optional[Role], User]:
+    def signup(
+        self, roleToSet: Role, user: discord.abc.User, replace=False
+    ) -> Tuple[Optional[Role], User]:
         """Add username to role.
 
         Raises an error if the role is taken, unless replace is set to True.
@@ -478,9 +515,10 @@ class Event:
             for role in roleGroup.roles:
                 if role == roleToSet:
                     if role.userID and not replace:
-                        raise RoleTaken(f"Can't sign up {user.display_name}, "
-                                        f"role {roleToSet.name} is already "
-                                        "taken")
+                        raise RoleTaken(
+                            f"Can't sign up {user.display_name}, "
+                            f"role {roleToSet.name} is already taken"
+                        )
                     old_user = User(role.userID, role.userName)
                     old_role = self.undoSignup(user)
                     role.userID = user.id
@@ -518,7 +556,8 @@ class Event:
         """Add user to the attendance list"""
         if not self.has_attendee(user):
             self.attendees.append(
-                User(id=user.id, display_name=user.display_name))
+                User(id=user.id, display_name=user.display_name)
+            )
 
     def remove_attendee(self, user: discord.abc.User) -> None:
         """Remove user from the attendance list"""
@@ -560,8 +599,9 @@ class Event:
     def fromJson(self, eventID, data: dict, emojis, manual_load=False):
         self.id = int(eventID)
         self.title = data.get("title", None)
-        self.time = datetime.datetime.strptime(data.get("time", "00:00"),
-                                               "%H:%M")
+        self.time = datetime.datetime.strptime(
+            data.get("time", "00:00"), "%H:%M"
+        )
         self.terrain = data.get("terrain", TERRAIN)
         self.faction = str(data.get("faction", FACTION))
         self.port = int(data.get("port", cfg.PORT_DEFAULT))

--- a/src/operationbot/event.py
+++ b/src/operationbot/event.py
@@ -31,7 +31,7 @@ class User:
     # This class implements the same signature as the discord.abc.User class,
     # we need to use the 'id' argument here.
     # pylint: disable=redefined-builtin
-    def __init__(self, id: int = None, display_name: str = None):
+    def __init__(self, id: int | None = None, display_name: str | None = None):
         self.id = id
         self.display_name = display_name
 
@@ -133,7 +133,8 @@ class Event:
             msg = ""
             role = sourceGroup[roleName]
             print(
-                f"moving role {roleName} from {sourceGroup.name} to {targetGroupName}"
+                f"moving role {roleName} from {sourceGroup.name} "
+                f"to {targetGroupName}"
             )
             if targetGroupName is None:
                 if role.userID is not None:
@@ -232,7 +233,7 @@ class Event:
             else:
                 raise ValueError(
                     "Unsupported platoon size conversion: "
-                    "{self.platoon_size} -> {new_size}"
+                    f"{self.platoon_size} -> {new_size}"
                 )
         elif self.platoon_size == "1PLT":
             if new_size == "2PLT":
@@ -241,7 +242,8 @@ class Event:
                     "Conversion from 1PLT to 2PLT not implemented"
                 )
             raise ValueError(
-                "Unsupported platoon size conversion: {self.platoon_size} -> {new_size}"
+                "Unsupported platoon size conversion: "
+                f"{self.platoon_size} -> {new_size}"
             )
         else:
             raise ValueError(
@@ -354,7 +356,8 @@ class Event:
             for role in roleGroup.roles:
                 if role.name == name:
                     raise RoleError(
-                        f"Role with name {name} already exists, not adding new role"
+                        f"Role with name {name} already exists, "
+                        "not adding new role"
                     )
 
         # Find next emoji for additional role
@@ -371,7 +374,10 @@ class Event:
         return emoji
 
     def _check_additional(self, role: Role):
-        """Raises a RoleError if the supplied role is not an additional role"""
+        """Check if the supplied role is an additional role.
+
+        Raises a RoleError if it is not.
+        """
         if role not in self.roleGroups["Additional"].roles:
             raise RoleError(f"Role {role.name} is not an additional role")
 
@@ -388,8 +394,7 @@ class Event:
         self.roleGroups["Additional"].removeRole(role)
 
     def removeRoleGroup(self, groupName: str) -> bool:
-        """
-        Remove a role group.
+        """Remove a role group.
 
         Returns false if the group cannot be found.
         """
@@ -476,7 +481,8 @@ class Event:
     def findRoleWithName(self, roleName: str) -> Role:
         """Find a role with given name.
 
-        Raises a RoleNotFound if the role cannot be found."""
+        Raises a RoleNotFound if the role cannot be found.
+        """
         roleName = roleName.lower()
         for roleGroup in self.roleGroups.values():
             role: Role
@@ -503,7 +509,7 @@ class Event:
     def signup(
         self, roleToSet: Role, user: discord.abc.User, replace=False
     ) -> Tuple[Optional[Role], User]:
-        """Add username to role.
+        """Add user to a role.
 
         Raises an error if the role is taken, unless replace is set to True.
 
@@ -528,9 +534,10 @@ class Event:
         raise RoleNotFound(f"Could not find role: {roleToSet}")
 
     def undoSignup(self, user) -> Optional[Role]:
-        """Remove username from any signups.
+        """Remove user from any signups.
 
-        Returns Role if user was signed up, otherwise None."""
+        Returns Role if user was signed up, otherwise None.
+        """
         for roleGroup in self.roleGroups.values():
             for role in roleGroup.roles:
                 if role.userID == user.id:

--- a/src/operationbot/eventDatabase.py
+++ b/src/operationbot/eventDatabase.py
@@ -47,8 +47,8 @@ class EventDatabase:
         # Create event
         event = Event(
             date,
-            cls.emojis,
-            eventID=eventID,  # type: ignore
+            cls.emojis,  # type: ignore
+            eventID=eventID,
             importing=importing,
             sideop=sideop,
             platoon_size=platoon_size,
@@ -61,8 +61,7 @@ class EventDatabase:
 
     @classmethod
     def archiveEvent(cls, event: Event):
-        """
-        Move event to archive.
+        """Move event to archive.
 
         Does not remove or create messages.
         """
@@ -76,8 +75,7 @@ class EventDatabase:
 
     @classmethod
     def removeEvent(cls, eventID: int, archived=False) -> Optional[Event]:
-        """
-        Remove event.
+        """Remove event.
 
         Does not remove the message associated with the event.
         """
@@ -87,9 +85,10 @@ class EventDatabase:
     # was: findEvent
     @classmethod
     def getEventByMessage(cls, messageID: int, archived=False) -> Event:
-        """Finds an event with its message ID.
+        """Find an event with its message ID.
 
-        Raises EventNotFound if event cannot be found"""
+        Raises EventNotFound if event cannot be found
+        """
         if archived:
             collection = cls.eventsArchive
         else:
@@ -102,9 +101,10 @@ class EventDatabase:
 
     @classmethod
     def getEventByID(cls, eventID: int, archived=False) -> Event:
-        """Finds an event with its ID.
+        """Find an event with its ID.
 
-        Raises EventNotFound if event cannot be found."""
+        Raises EventNotFound if event cannot be found.
+        """
         if archived:
             collection = cls.eventsArchive
         else:
@@ -117,18 +117,19 @@ class EventDatabase:
 
     @classmethod
     def getArchivedEventByMessage(cls, messageID: int) -> Event:
-        """Finds an archived event with its message ID.
+        """Find an archived event with its message ID.
 
-        Raises EventNotFound if event cannot be found"""
-
+        Raises EventNotFound if event cannot be found
+        """
         return cls.getEventByMessage(messageID, archived=True)
 
     # was: findEventInArchiveeventid
     @classmethod
     def getArchivedEventByID(cls, eventID: int):
-        """Finds an archived event with its ID.
+        """Find an archived event with its ID.
 
-        Raises EventNotFound if event cannot be found."""
+        Raises EventNotFound if event cannot be found.
+        """
         return cls.getEventByID(eventID, archived=True)
 
     @classmethod
@@ -208,7 +209,8 @@ class EventDatabase:
                     data: Dict = json.load(jsonFile)
             except json.decoder.JSONDecodeError as e:
                 print(
-                    "Malformed JSON file! Backing up and creating an empty database"
+                    "Malformed JSON file! Backing up and "
+                    "creating an empty database"
                 )
                 backup_date = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
                 # Backup old file

--- a/src/operationbot/eventDatabase.py
+++ b/src/operationbot/eventDatabase.py
@@ -30,8 +30,9 @@ class EventDatabase:
         return cls._emojis
 
     @classmethod
-    def createEvent(cls, date: datetime, eventID: int = -1,
-                    sideop=False, platoon_size=None) -> Event:
+    def createEvent(
+        cls, date: datetime, eventID: int = -1, sideop=False, platoon_size=None
+    ) -> Event:
         """Create a new event and store it.
 
         Does not create a message for the event.
@@ -44,9 +45,14 @@ class EventDatabase:
             importing = True
 
         # Create event
-        event = Event(date, cls.emojis, eventID=eventID,  # type: ignore
-                      importing=importing,
-                      sideop=sideop, platoon_size=platoon_size)
+        event = Event(
+            date,
+            cls.emojis,
+            eventID=eventID,  # type: ignore
+            importing=importing,
+            sideop=sideop,
+            platoon_size=platoon_size,
+        )
 
         # Store event
         cls.events[eventID] = event
@@ -107,8 +113,7 @@ class EventDatabase:
         try:
             return collection[eventID]
         except KeyError as e:
-            raise EventNotFound(f"No event found with ID {eventID}") \
-                from e
+            raise EventNotFound(f"No event found with ID {eventID}") from e
 
     @classmethod
     def getArchivedEventByMessage(cls, messageID: int) -> Event:
@@ -151,7 +156,7 @@ class EventDatabase:
     def toJson(cls, archive=False):
         # TODO: rename to saveDatabase
         events = cls.events if not archive else cls.eventsArchive
-        filename = cfg.JSON_FILEPATH['events' if not archive else 'archive']
+        filename = cfg.JSON_FILEPATH["events" if not archive else "archive"]
 
         cls.writeJson(events, filename)
 
@@ -164,12 +169,12 @@ class EventDatabase:
 
         # Store data and return
         data: Dict[str, Any] = {}
-        data['version'] = DATABASE_VERSION
-        data['nextID'] = cls.nextID
-        data['events'] = eventsData
+        data["version"] = DATABASE_VERSION
+        data["nextID"] = cls.nextID
+        data["events"] = eventsData
 
         os.makedirs(os.path.dirname(filename), exist_ok=True)
-        with open(filename, 'w') as jsonFile:
+        with open(filename, "w") as jsonFile:
             json.dump(data, jsonFile, indent=2)
 
     @classmethod
@@ -179,14 +184,16 @@ class EventDatabase:
                 raise ValueError("No emojis provided")
             cls._emojis = emojis
         print("Importing events")
-        cls.events, cls.nextID = cls.readJson(cfg.JSON_FILEPATH['events'])
+        cls.events, cls.nextID = cls.readJson(cfg.JSON_FILEPATH["events"])
         print("Importing archive")
         cls.eventsArchive, _ = cls.readJson(
-            cfg.JSON_FILEPATH['archive'], output_events=False)
+            cfg.JSON_FILEPATH["archive"], output_events=False
+        )
 
     @classmethod
-    def readJson(cls, filename: str, output_events=True) \
-            -> Tuple[Dict[int, Event], int]:
+    def readJson(
+        cls, filename: str, output_events=True
+    ) -> Tuple[Dict[int, Event], int]:
         """Fill events and eventsArchive with data from JSON."""
         print("Importing")
 
@@ -200,9 +207,10 @@ class EventDatabase:
                 with open(filename) as jsonFile:
                     data: Dict = json.load(jsonFile)
             except json.decoder.JSONDecodeError as e:
-                print("Malformed JSON file! Backing up and",
-                      "creating an empty database")
-                backup_date = datetime.now().strftime('%Y-%m-%dT%H-%M-%S')
+                print(
+                    "Malformed JSON file! Backing up and creating an empty database"
+                )
+                backup_date = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
                 # Backup old file
                 backupName = f"{filename}-{backup_date}.bak"
                 os.rename(filename, backupName)
@@ -214,32 +222,37 @@ class EventDatabase:
             os.makedirs(os.path.dirname(filename), exist_ok=True)
             with open(filename, "w") as jsonFile:
                 # Create a new file with empty JSON structure inside
-                json.dump({
-                    "version": DATABASE_VERSION,
-                    "nextID": 0,
-                    "events": {},
-                }, jsonFile, indent=2)
+                json.dump(
+                    {
+                        "version": DATABASE_VERSION,
+                        "nextID": 0,
+                        "events": {},
+                    },
+                    jsonFile,
+                    indent=2,
+                )
             # Try to import again
             return cls.readJson(filename)
 
-        databaseVersion = int(data.get('version', 0))
+        databaseVersion = int(data.get("version", 0))
         if databaseVersion != DATABASE_VERSION:
-            msg = ("Incorrect database version. Expected: "
-                   f"{DATABASE_VERSION}, got: {databaseVersion}.")
+            msg = (
+                "Incorrect database version. Expected: "
+                f"{DATABASE_VERSION}, got: {databaseVersion}."
+            )
             print(msg)
             raise ValueError(msg)
 
         events = {}
-        nextID = data['nextID']
-        eventsData: Dict[str, Any] = data['events']
+        nextID = data["nextID"]
+        eventsData: Dict[str, Any] = data["events"]
 
         # Add events
         for eventID, eventData in [
-                (int(_id), _data)
-                for _id, _data in eventsData.items()]:
+            (int(_id), _data) for _id, _data in eventsData.items()
+        ]:
             # Create event
-            date = datetime.strptime(eventData['date'],
-                                     '%Y-%m-%d')
+            date = datetime.strptime(eventData["date"], "%Y-%m-%d")
             # NOTE: Ignoring the type here because mypy is buggy and doesn't
             # detect class properties correctly
             event = Event(date, emojis, importing=True)  # type: ignore

--- a/src/operationbot/eventListener.py
+++ b/src/operationbot/eventListener.py
@@ -9,6 +9,7 @@ from discord.user import User
 
 from operationbot import config as cfg
 from operationbot import messageFunctions as msgFnc
+from operationbot.bot import OperationBot
 from operationbot.errors import (
     EventNotFound,
     RoleNotFound,
@@ -17,7 +18,6 @@ from operationbot.errors import (
 )
 from operationbot.event import Event
 from operationbot.eventDatabase import EventDatabase
-from operationbot.bot import OperationBot
 from operationbot.role import Role
 
 
@@ -33,7 +33,8 @@ class EventListener(Cog):
         commandchannel = self.bot.commandchannel
         print(f"Logged in as {self.bot.user.name} {self.bot.user.id}")
         print(
-            f"Command channel: {commandchannel} on server {commandchannel.guild}"
+            f"Command channel: {commandchannel} "
+            f"on server {commandchannel.guild}"
         )
         await commandchannel.send("Connected")
         print("Ready, importing")
@@ -120,7 +121,8 @@ class EventListener(Cog):
             role = event.findRoleWithEmoji(emoji)
         except RoleNotFound as e:
             raise RoleNotFound(
-                f"{str(e)} in event {event} by user {user.name}#{user.discriminator}"
+                f"{str(e)} in event {event} "
+                f"by user {user.name}#{user.discriminator}"
             ) from e
 
         if role.name == cfg.EMOJI_ZEUS:
@@ -195,7 +197,7 @@ class EventListener(Cog):
             EventDatabase.toJson()
         else:
             raise UnknownEmoji(
-                f"Reaction to unknown special emoji {emoji}"
+                f"Reaction to unknown special emoji {emoji} "
                 f"in event {event} by user {user}"
             )
 
@@ -207,9 +209,13 @@ class EventListener(Cog):
             owner = self.bot.owner
             await owner.send(f"DM: [{message.author}]: {message.content}")
 
-    def _calculate_signoff_delta(self, event: Event, role: Role, user):
-        """return a string (days or hours/mins) if it is shortly before op
-        else None"""
+    def _calculate_signoff_delta(
+        self, event: Event, role: Role, user
+    ) -> str | None:
+        """Return a time difference (days or hours/mins) to the op
+
+        If the time difference is greater than a certain threshold, returns None
+        """
         if role.name in cfg.SIGNOFF_NOTIFY_ROLES.get(event.platoon_size, []):
             time_delta = event.date - datetime.today()
             if time_delta > timedelta(days=0):

--- a/src/operationbot/eventListener.py
+++ b/src/operationbot/eventListener.py
@@ -9,7 +9,12 @@ from discord.user import User
 
 from operationbot import config as cfg
 from operationbot import messageFunctions as msgFnc
-from operationbot.errors import EventNotFound, RoleNotFound, RoleTaken, UnknownEmoji
+from operationbot.errors import (
+    EventNotFound,
+    RoleNotFound,
+    RoleTaken,
+    UnknownEmoji,
+)
 from operationbot.event import Event
 from operationbot.eventDatabase import EventDatabase
 from operationbot.bot import OperationBot
@@ -17,7 +22,6 @@ from operationbot.role import Role
 
 
 class EventListener(Cog):
-
     def __init__(self, bot: OperationBot):
         self.bot = bot
 
@@ -28,8 +32,9 @@ class EventListener(Cog):
         self.bot.fetch_data()
         commandchannel = self.bot.commandchannel
         print(f"Logged in as {self.bot.user.name} {self.bot.user.id}")
-        print(f"Command channel: {commandchannel} on server "
-              f"{commandchannel.guild}")
+        print(
+            f"Command channel: {commandchannel} on server {commandchannel.guild}"
+        )
         await commandchannel.send("Connected")
         print("Ready, importing")
         await commandchannel.send("Importing events")
@@ -42,14 +47,16 @@ class EventListener(Cog):
         print(msg)
         await commandchannel.send(msg)
         await self.bot.change_presence(activity=Game(name=cfg.GAME))
-        print('Logged in as', self.bot.user.name, self.bot.user.id)
+        print("Logged in as", self.bot.user.name, self.bot.user.id)
         self.bot.processing = False
 
     @Cog.listener()
     async def on_raw_reaction_add(self, payload: RawReactionActionEvent):
 
-        if payload.member == self.bot.user or \
-                payload.channel_id != self.bot.eventchannel.id:
+        if (
+            payload.member == self.bot.user
+            or payload.channel_id != self.bot.eventchannel.id
+        ):
             # Bot's own reaction, or reaction outside of the event channel
             return
 
@@ -57,7 +64,8 @@ class EventListener(Cog):
             return
 
         message: Message = await self.bot.eventchannel.fetch_message(
-            payload.message_id)
+            payload.message_id
+        )
         if message.author != self.bot.user:
             # We don't care about reactions to other messages than our own.
             # Makes it easier to test multiple bot instances on the same
@@ -76,9 +84,9 @@ class EventListener(Cog):
             await self.bot.logchannel.send(
                 "NOTE: reaction to a non-existent event. "
                 f"msg: {message.id} role: {payload.emoji} "
-                f"user: {user.display_name} "
-                f"({user.name}#{user.discriminator})\n"
-                f"{message.jump_url}")
+                f"user: {user.display_name} ({user.name}#{user.discriminator})\n"
+                f"{message.jump_url}"
+            )
             return
         else:
             if payload.emoji.is_custom_emoji():
@@ -87,14 +95,17 @@ class EventListener(Cog):
                 emoji = cast(str, payload.emoji.name)
 
             if payload.emoji.name in cfg.SPECIAL_EMOJIS:
-                await self._handle_special_emoji(event, emoji, user,
-                                                 message)
+                await self._handle_special_emoji(event, emoji, user, message)
             else:
                 await self._handle_signup(event, emoji, user, message)
 
-    async def _handle_signup(self, event: Event,
-                             emoji: Union[PartialEmoji, str], user: User,
-                             message: Message):
+    async def _handle_signup(
+        self,
+        event: Event,
+        emoji: Union[PartialEmoji, str],
+        user: User,
+        message: Message,
+    ):
         # Find signup of user
         old_signup: Optional[Role] = event.findSignupRole(user.id)
 
@@ -108,8 +119,9 @@ class EventListener(Cog):
         try:
             role = event.findRoleWithEmoji(emoji)
         except RoleNotFound as e:
-            raise RoleNotFound(f"{str(e)} in event {event} by user "
-                               f"{user.name}#{user.discriminator}") from e
+            raise RoleNotFound(
+                f"{str(e)} in event {event} by user {user.name}#{user.discriminator}"
+            ) from e
 
         if role.name == cfg.EMOJI_ZEUS:
             # Somebody with Nitro added the ZEUS reaction by hand, ignoring
@@ -150,22 +162,29 @@ class EventListener(Cog):
             # User signed off or changed role, checking if there's a need to
             # ping
             late_signoff_delta = self._calculate_signoff_delta(
-                event, removed_role, user)
+                event, removed_role, user
+            )
             if late_signoff_delta is not None and not event.sideop:
-                delta_message = (f"{self.bot.signoff_notify_user.mention}: "
-                                 f"{late_signoff_delta} before the "
-                                 "operation:\n")
+                delta_message = (
+                    f"{self.bot.signoff_notify_user.mention}: "
+                    f"{late_signoff_delta} before the operation:\n"
+                )
 
-        text = f"{delta_message}{message_action}: {event}, role: " \
-               f"{old_role}{role.display_name}, " \
-               f"user: {user.display_name} " \
-               f"({user.name}#{user.discriminator})"
+        text = (
+            f"{delta_message}{message_action}: {event}, "
+            f"role: {old_role}{role.display_name}, "
+            f"user: {user.display_name} ({user.name}#{user.discriminator})"
+        )
 
         await self.bot.logchannel.send(text)
 
-    async def _handle_special_emoji(self, event: Event,
-                                    emoji: Union[PartialEmoji, str],
-                                    user: User, message: Message):
+    async def _handle_special_emoji(
+        self,
+        event: Event,
+        emoji: Union[PartialEmoji, str],
+        user: User,
+        message: Message,
+    ):
 
         if emoji == cfg.ATTENDANCE_EMOJI:
             if event.has_attendee(user):
@@ -175,8 +194,10 @@ class EventListener(Cog):
             await msgFnc.updateMessageEmbed(message, event)
             EventDatabase.toJson()
         else:
-            raise UnknownEmoji(f"Reaction to unknown special emoji {emoji} "
-                               f"in event {event} by user {user}")
+            raise UnknownEmoji(
+                f"Reaction to unknown special emoji {emoji}"
+                f"in event {event} by user {user}"
+            )
 
     @Cog.listener()
     async def on_message(self, message: Message):
@@ -199,8 +220,10 @@ class EventListener(Cog):
                     timeframe = f"{days} days"
                 else:
                     timeframe = f"{hours}h{mins}min"
-                if time_delta < cfg.SIGNOFF_NOTIFY_TIME and \
-                        self.bot.signoff_notify_user != user:
+                if (
+                    time_delta < cfg.SIGNOFF_NOTIFY_TIME
+                    and self.bot.signoff_notify_user != user
+                ):
                     return timeframe
         return None
 

--- a/src/operationbot/main.py
+++ b/src/operationbot/main.py
@@ -4,9 +4,8 @@ import sys
 import discord
 
 from operationbot import config as cfg
-from operationbot.bot import OperationBot
-
 from operationbot import secret as s
+from operationbot.bot import OperationBot
 from operationbot.secret import COMMAND_CHAR, TOKEN
 
 CONFIG_VERSION = 12

--- a/src/operationbot/main.py
+++ b/src/operationbot/main.py
@@ -14,16 +14,18 @@ SECRET_VERSION = 1
 if cfg.VERSION != CONFIG_VERSION:
     raise ValueError(
         f"Incompatible config file, expecting version {CONFIG_VERSION}, "
-        f"found version {cfg.VERSION}")
+        f"found version {cfg.VERSION}"
+    )
 if s.VERSION != SECRET_VERSION:
     raise ValueError(
         f"Incompatible secrets file, expecting version {SECRET_VERSION}, "
-        f"found version {s.VERSION}")
+        f"found version {s.VERSION}"
+    )
 
 initial_extensions = [
-    'operationbot.commandListener',
-    'operationbot.eventListener',
-    'operationbot.cogs.repl',
+    "operationbot.commandListener",
+    "operationbot.eventListener",
+    "operationbot.cogs.repl",
 ]
 
 intents = discord.Intents.default()
@@ -38,7 +40,7 @@ if sys.version_info < (3, 10):
 
 def main():
     print("Starting up")
-    bot.load_extension('operationbot.reload')
+    bot.load_extension("operationbot.reload")
     print("Loading extensions")
     for extension in initial_extensions:
         # try:

--- a/src/operationbot/main.py
+++ b/src/operationbot/main.py
@@ -32,8 +32,8 @@ intents.messages = True  # pylint: disable=assigning-non-slot
 bot = OperationBot(command_prefix=COMMAND_CHAR, intents=intents)
 # bot.remove_command("help")
 
-if sys.version_info < (3, 9):
-    raise Exception("Must be run with Python 3.9 or higher")
+if sys.version_info < (3, 10):
+    raise Exception("Must be run with Python 3.10 or higher")
 
 
 def main():

--- a/src/operationbot/messageFunctions.py
+++ b/src/operationbot/messageFunctions.py
@@ -10,8 +10,9 @@ from operationbot.eventDatabase import EventDatabase
 from operationbot.bot import OperationBot
 
 
-async def getEventMessage(event: Event, bot: OperationBot, archived=False) \
-        -> Message:
+async def getEventMessage(
+    event: Event, bot: OperationBot, archived=False
+) -> Message:
     """Get a message related to an event."""
     if archived:
         channel = bot.eventarchivechannel
@@ -21,8 +22,9 @@ async def getEventMessage(event: Event, bot: OperationBot, archived=False) \
     try:
         return await channel.fetch_message(event.messageID)
     except NotFound as e:
-        raise MessageNotFound("No event message found with "
-                              f"message ID {event.messageID}") from e
+        raise MessageNotFound(
+            f"No event message found with message ID {event.messageID}"
+        ) from e
 
 
 async def sortEventMessages(bot: OperationBot):
@@ -42,8 +44,9 @@ async def sortEventMessages(bot: OperationBot):
 
 
 # from EventDatabase
-async def createEventMessage(event: Event, channel: TextChannel,
-                             update_id=True) -> Message:
+async def createEventMessage(
+    event: Event, channel: TextChannel, update_id=True
+) -> Message:
     """Create a new event message."""
     # Create embed and message
     embed = event.createEmbed()
@@ -55,16 +58,18 @@ async def createEventMessage(event: Event, channel: TextChannel,
 
 
 # was: EventDatabase.updateEvent
-async def updateMessageEmbed(eventMessage: Message, updatedEvent: Event) \
-        -> None:
+async def updateMessageEmbed(
+    eventMessage: Message, updatedEvent: Event
+) -> None:
     """Update the embed and footer of a message."""
     newEventEmbed = updatedEvent.createEmbed()
     await eventMessage.edit(embed=newEventEmbed)
 
 
 # from EventDatabase
-async def updateReactions(event: Event, message: Message = None, bot=None,
-                          reorder=False):
+async def updateReactions(
+    event: Event, message: Message = None, bot=None, reorder=False
+):
     """
     Update reactions of an event message.
 
@@ -74,8 +79,9 @@ async def updateReactions(event: Event, message: Message = None, bot=None,
     """
     if message is None:
         if bot is None:
-            raise ValueError("Requires either the `message` or `bot` argument"
-                             " to be provided")
+            raise ValueError(
+                "Requires either the `message` or `bot` argument to be provided"
+            )
         message = await getEventMessage(event, bot)
 
     reactions: List[Union[Emoji, str]] = event.getReactions()
@@ -117,8 +123,11 @@ async def updateReactions(event: Event, message: Message = None, bot=None,
             await message.add_reaction(emoji)
         except Forbidden as e:
             if e.code == 30010:
-                raise RoleError("Too many reactions, not adding role "
-                                f"{emoji}. This should not happen.") from e
+                raise RoleError(
+                    "Too many reactions, not adding role "
+                    f"{emoji}. This should not happen."
+                ) from e
+
 
 # async def createMessages(events: Dict[int, Event], bot):
 #     # Update event message contents and add reactions
@@ -143,7 +152,7 @@ def messageEventId(message: Message) -> int:
         raise ValueError("Footer is empty")
     # Casting because mypy doesn't detect correctly that the type of
     # footer.text has been checked already
-    return int(cast(str, footer.text).split(' ')[-1])
+    return int(cast(str, footer.text).split(" ")[-1])
 
 
 async def syncMessages(events: Dict[int, Event], bot: OperationBot):
@@ -158,8 +167,9 @@ async def syncMessages(events: Dict[int, Event], bot: OperationBot):
             if messageEventId(message) == event.id:
                 print(f"Found message {message.id} for event {event}")
             else:
-                print(f"Found incorrect message for event {event}, deleting "
-                      f"and creating")
+                print(
+                    f"Found incorrect message for event {event}, deleting and creating"
+                )
                 # Technically multiple events might have the same saved
                 # messageID but it's simpler to just recreate messages here if
                 # the event ID doesn't match

--- a/src/operationbot/messageFunctions.py
+++ b/src/operationbot/messageFunctions.py
@@ -4,10 +4,10 @@ from discord import Emoji, Message, NotFound, TextChannel
 from discord.embeds import Embed
 from discord.errors import Forbidden
 
+from operationbot.bot import OperationBot
 from operationbot.errors import MessageNotFound, RoleError
 from operationbot.event import Event
 from operationbot.eventDatabase import EventDatabase
-from operationbot.bot import OperationBot
 
 
 async def getEventMessage(
@@ -30,7 +30,8 @@ async def getEventMessage(
 async def sortEventMessages(bot: OperationBot):
     """Sort events in event database.
 
-    Raises MessageNotFound if messages are missing."""
+    Raises MessageNotFound if messages are missing.
+    """
     EventDatabase.sortEvents()
 
     event: Event
@@ -68,10 +69,9 @@ async def updateMessageEmbed(
 
 # from EventDatabase
 async def updateReactions(
-    event: Event, message: Message = None, bot=None, reorder=False
+    event: Event, message: Message | None = None, bot=None, reorder=False
 ):
-    """
-    Update reactions of an event message.
+    """Update reactions of an event message.
 
     Requires either the `message` or `bot` argument to be provided. Calling
     the function with reorder = True causes all reactions to be removed and
@@ -168,7 +168,8 @@ async def syncMessages(events: Dict[int, Event], bot: OperationBot):
                 print(f"Found message {message.id} for event {event}")
             else:
                 print(
-                    f"Found incorrect message for event {event}, deleting and creating"
+                    f"Found incorrect message for event {event}, "
+                    "deleting and creating"
                 )
                 # Technically multiple events might have the same saved
                 # messageID but it's simpler to just recreate messages here if

--- a/src/operationbot/reload.py
+++ b/src/operationbot/reload.py
@@ -18,8 +18,9 @@ class Reload(Cog):
                 self.bot.unload_extension(extension)
                 print("unloaded", extension)
             except ExtensionNotLoaded:
-                await ctx.send("Skipping unload for not loaded extension "
-                               f"{extension}")
+                await ctx.send(
+                    f"Skipping unload for not loaded extension {extension}"
+                )
             else:
                 unloaded.append(extension)
         loaded = []
@@ -28,17 +29,19 @@ class Reload(Cog):
                 self.bot.load_extension(extension)
                 print("loaded", extension)
             except Exception:  # pylint: disable=broad-except
-                await ctx.send("An error occured while reloading: "
-                               f"```py\n{traceback.format_exc()}```")
+                await ctx.send(
+                    "An error occured while reloading: "
+                    f"```py\n{traceback.format_exc()}```"
+                )
             else:
                 loaded.append(extension)
         if len(loaded) > 0:
-            await ctx.send(
-                f"Reloaded following extensions: {loaded}")
+            await ctx.send(f"Reloaded following extensions: {loaded}")
             not_loaded = [item for item in unloaded if item not in loaded]
             if len(not_loaded) > 0:
-                await ctx.send("Failed to reload following extensions: "
-                               f"{not_loaded}")
+                await ctx.send(
+                    f"Failed to reload following extensions: {not_loaded}"
+                )
 
 
 def setup(bot):

--- a/src/operationbot/role.py
+++ b/src/operationbot/role.py
@@ -4,9 +4,9 @@ from discord import Emoji
 
 
 class Role:
-
-    def __init__(self, name: str, emoji: Union[str, Emoji],
-                 show_name: bool = False):
+    def __init__(
+        self, name: str, emoji: Union[str, Emoji], show_name: bool = False
+    ):
         self.name = name
         self.emoji = emoji
         self.show_name = show_name

--- a/src/operationbot/roleGroup.py
+++ b/src/operationbot/roleGroup.py
@@ -8,7 +8,6 @@ from operationbot.role import Role
 
 
 class RoleGroup:
-
     def __init__(self, name: str, isInline: bool = True):
         self.name = name
         self.isInline = isInline
@@ -50,13 +49,14 @@ class RoleGroup:
             # for now
             raise RoleNotFound(
                 "Could not find an additional role to remove "
-                f"with the name {name}") from e  # pylint: disable=E0601
+                f"with the name {name}"  # pylint: disable=E0601
+            ) from e
 
     def __str__(self) -> str:
         roleGroupString = ""
 
         for role in self.roles:
-            roleGroupString += f'{str(role)}\n'
+            roleGroupString += f"{str(role)}\n"
 
         return roleGroupString
 
@@ -76,8 +76,9 @@ class RoleGroup:
         data["roles"] = rolesData
         return data
 
-    def fromJson(self, data: dict, emojis: Tuple[Emoji, ...],
-                 manual_load=False):
+    def fromJson(
+        self, data: dict, emojis: Tuple[Emoji, ...], manual_load=False
+    ):
         self.name = data["name"]
         if not manual_load:
             self.isInline = data["isInline"]
@@ -94,16 +95,20 @@ class RoleGroup:
             if not manual_load:
                 # Only create new roles if we're not loading data manually from
                 # the command channel
-                role = Role(roleData["name"], roleEmoji,
-                            self.get_corrected_name(roleData))
+                role = Role(
+                    roleData["name"],
+                    roleEmoji,
+                    self.get_corrected_name(roleData),
+                )
                 self.roles.append(role)
             else:
                 try:
                     role = next(x for x in self.roles if x.emoji == roleEmoji)
                 except StopIteration as e:
                     name = roleData.get("show_name") or roleData["name"]
-                    raise UnexpectedRole(f"Cannot import unexpected role "
-                                         f"'{name}'") from e
+                    raise UnexpectedRole(
+                        f"Cannot import unexpected role '{name}'"
+                    ) from e
                 roles.append(roleEmoji)
 
             role.fromJson(roleData, manual_load=manual_load)

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -5,13 +5,14 @@ from operationbot.event import Event
 
 
 def _timestamp(date: datetime) -> int:
-    return int(date.replace(tzinfo=cfg.TIME_ZONE)
-               .astimezone(timezone.utc).timestamp())
+    return int(
+        date.replace(tzinfo=cfg.TIME_ZONE).astimezone(timezone.utc).timestamp()
+    )
 
 
 def test_default():
     date = datetime(2020, 1, 1, 12, 0, 0)
-    event = Event(date, (), platoon_size='empty')
+    event = Event(date, (), platoon_size="empty")
 
     assert event.date == date
     assert event.time == time(hour=date.hour, minute=date.minute)
@@ -19,37 +20,39 @@ def test_default():
     event.date = date
     assert event.date == date
 
-    event.faction = 'USMC'
-    assert event.faction == 'USMC'
+    event.faction = "USMC"
+    assert event.faction == "USMC"
 
-    event.terrain = 'Stratis'
-    assert event.terrain == 'Stratis'
+    event.terrain = "Stratis"
+    assert event.terrain == "Stratis"
 
-    assert event.title == 'Operation'
-    assert event.description == ''
+    assert event.title == "Operation"
+    assert event.description == ""
     timestamp = _timestamp(date)
     assert event.createEmbed().description == (
         f"Local time: <t:{timestamp}> "
         f"(<t:{timestamp}:R>)"
-        f"\nTerrain: Stratis - Faction: USMC")
+        f"\nTerrain: Stratis - Faction: USMC"
+    )
 
 
 def test_dlc():
     date = datetime(2020, 1, 1, 12, 0, 0)
-    event = Event(date, (), platoon_size='empty')
+    event = Event(date, (), platoon_size="empty")
 
-    event.terrain = 'Tanoa'
-    assert event.terrain == 'Tanoa'
-    assert event.faction == 'unknown'
-    assert event.title == 'APEX Operation'
-    assert event.description == ''
+    event.terrain = "Tanoa"
+    assert event.terrain == "Tanoa"
+    assert event.faction == "unknown"
+    assert event.title == "APEX Operation"
+    assert event.description == ""
     timestamp = _timestamp(date)
     assert event.createEmbed().description == (
         f"Local time: <t:{timestamp}> "
         f"(<t:{timestamp}:R>)"
         f"\nTerrain: {event.terrain} - Faction: {event.faction}\n\n"
-        f"The **{event.dlc} DLC** is required to join this event")
-    event.terrain = 'Stratis'
+        f"The **{event.dlc} DLC** is required to join this event"
+    )
+    event.terrain = "Stratis"
     assert event.dlc is None
-    event.dlc = 'GlobMob'
-    assert event.dlc == 'GlobMob'
+    event.dlc = "GlobMob"
+    assert event.dlc == "GlobMob"


### PR DESCRIPTION
Formatted the code automatically with black, formatted docstrings manually and added type hints required by mypy.

- Changed required Python version to 3.10
  - This allows using the new `TypeA | TypeB` syntax introduced in Python 3.10.
- Added black formatter
- Added isort
- Replaced ruff with flake8 + bugbear, because they handle long lines better (B950)
- Set line length back to 79
- Added markdownlint