### PR TITLE
Use a placeholder message if an error doesn't have one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The project uses semantic versioning (see [SemVer](https://semver.org)).
 
 ## [Unreleased]
 
+### Fixed
+
+- Use a placeholder message if a command error doesn't include one. This
+  should fix some of the incorrect warnings about messages with >2000
+  characters when trying to edit old events.
+
 ## v0.45.0 - 2024-03-27
 
 ### Added

--- a/src/operationbot/commandListener.py
+++ b/src/operationbot/commandListener.py
@@ -1174,7 +1174,13 @@ class CommandListener(Cog):
             traceback.format_exception(type(error), error, error.__traceback__, 2)
         )
 
-        lines = ctx.message.clean_content.split("\n")
+        if hasattr(ctx, "message"):
+            lines = ctx.message.clean_content.split("\n")
+            clean_content = ctx.message.clean_content
+        else:
+            lines = "No associated message"
+            clean_content = lines
+
         logging.error(f"{lines=}")
         if len(lines) > 1:
             # Show only first line of the message
@@ -1190,7 +1196,7 @@ class CommandListener(Cog):
                 "Received error message that's over 2000 characters, check "
                 "the log for the full error."
             )
-            logging.error("Message:", ctx.message.clean_content)
+            logging.error("Message:", clean_content)
             msg = f"{msg[:1990]} [...]```"
         await ctx.send(msg)
 


### PR DESCRIPTION
It seems that sometimes the Context passed to an on_command_error does not have the `message` attribute, despite the documentation. Falling back to a placeholder message if that is the case