### PR TITLE
Fix incorrect message attribute in on_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The project uses semantic versioning (see [SemVer](https://semver.org)).
 
 ## [Unreleased]
 
+### Fixed
+
+- Do not try to read non-existent message in `on_error`. The error handler does
+  not actually receive a full context, this was a result of a confusingly named
+  variable.
+
 ## v0.45.1 - 2024-04-02
 
 ### Fixed

--- a/src/operationbot/bot.py
+++ b/src/operationbot/bot.py
@@ -133,6 +133,5 @@ class OperationBot(Bot):
                 "bot.on_error: Received error message that's over 2000 "
                 "characters, check the log for the full error."
             )
-            logging.error("Message:", ctx.message.clean_content)
             msg = f"{msg[:1990]} [...]```"
         await ctx.send(msg)

--- a/src/operationbot/bot.py
+++ b/src/operationbot/bot.py
@@ -130,8 +130,8 @@ class OperationBot(Bot):
         )
         if len(msg) >= 2000:
             await ctx.send(
-                "Received error message that's over 2000 characters, check "
-                "the log for the full error."
+                "bot.on_error: Received error message that's over 2000 "
+                "characters, check the log for the full error."
             )
             logging.error("Message:", ctx.message.clean_content)
             msg = f"{msg[:1990]} [...]```"

--- a/src/operationbot/bot.py
+++ b/src/operationbot/bot.py
@@ -123,15 +123,15 @@ class OperationBot(Bot):
         trace = traceback.format_exc(2)
         _, error, _ = sys.exc_info()
 
-        ctx = self.commandchannel
+        channel = self.commandchannel
         msg = (
             f"Unexpected error occured in {event_method}: ```{error}```\n"
             f"```py\n{trace}```"
         )
         if len(msg) >= 2000:
-            await ctx.send(
+            await channel.send(
                 "bot.on_error: Received error message that's over 2000 "
                 "characters, check the log for the full error."
             )
             msg = f"{msg[:1990]} [...]```"
-        await ctx.send(msg)
+        await channel.send(msg)

--- a/src/operationbot/bot.py
+++ b/src/operationbot/bot.py
@@ -117,8 +117,8 @@ class OperationBot(Bot):
             await self.close()
             sys.exit()
 
-    async def on_error(self, event_method, *args, **kwargs):
-        print(f"Error in {event_method=}")
+    async def on_error(self, event_method: str, *args, **kwargs):
+        logging.error(f"Error in {event_method=}")
         traceback.print_exc()
         trace = traceback.format_exc(2)
         _, error, _ = sys.exc_info()

--- a/src/operationbot/commandListener.py
+++ b/src/operationbot/commandListener.py
@@ -1193,8 +1193,8 @@ class CommandListener(Cog):
         )
         if len(msg) >= 2000:
             await ctx.send(
-                "Received error message that's over 2000 characters, check "
-                "the log for the full error."
+                "commandListener: Received error message that's over 2000 "
+                "characters, check the log for the full error."
             )
             logging.error("Message:", clean_content)
             msg = f"{msg[:1990]} [...]```"


### PR DESCRIPTION
Do not try to read non-existent message in `on_error`. The error handler does not actually receive a full context, this was a result of a confusingly named variable.