### PR TITLE
Add !sdlc, !cdlc commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The project uses semantic versioning (see [SemVer](https://semver.org)).
 
 ## [Unreleased]
 
+### Added
+
+- !setdlc (!sdlc) command for manually setting a DLC
+- !cleardlc (!cdlc) command for clearing a manually set DLC
+
 ## v0.46.0 - 2024-04-02
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<=3.13"
 
 [tool.poetry]
 name = "operationbot"
@@ -13,7 +13,7 @@ license = "GPL-3.0-or-later"
 operationbot = "operationbot.cli:cli"
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = ">=3.10"
 # Discord bot lib
 "discord.py" = ">=1.3.4,<2.0.0"
 # Yaml parser

--- a/src/operationbot/commandListener.py
+++ b/src/operationbot/commandListener.py
@@ -21,6 +21,7 @@ from discord.ext.commands.errors import (
 from operationbot import config as cfg
 from operationbot import messageFunctions as msgFnc
 from operationbot.bot import OperationBot
+from operationbot.command_helpers import show_event, update_event
 from operationbot.converters import (
     ArgArchivedEvent,
     ArgDate,
@@ -187,19 +188,12 @@ class CommandListener(Cog):
             await msgFnc.sortEventMessages(self.bot)
         if not silent:
             await ctx.send(f"Created event {event}")
-            await self._show(ctx, event)
+            await show_event(ctx, event, self.bot)
         return event
-
-    async def _show(self, ctx: Context, event: Event):
-        message = await msgFnc.getEventMessage(event, self.bot)
-        await ctx.send(f"<{message.jump_url}>")
-        await msgFnc.createEventMessage(
-            event, cast(TextChannel, ctx.channel), update_id=False
-        )
 
     @command(aliases=["cat"])
     async def show(self, ctx: Context, event: ArgEvent):
-        await self._show(ctx, event)
+        await show_event(ctx, event, self.bot)
 
     # Create event command
     @command(aliases=["c"])
@@ -277,7 +271,7 @@ class CommandListener(Cog):
         msg_zeus = f" with Zeus {zeus.display_name}" if zeus else ""
         if not quiet:
             await ctx.send(f"Created event {event}{msg_zeus}")
-            await self._show(ctx, event)
+            await show_event(ctx, event, self.bot)
         return event
 
     @command(aliases=["cq"])
@@ -468,7 +462,7 @@ class CommandListener(Cog):
         if ret.strip() != "":
             await ctx.send(ret)
 
-        await self._update_event(event)
+        await update_event(event, self.bot)
         await ctx.send("Event resized succesfully")
 
     @command(aliases=["csza"])
@@ -492,7 +486,7 @@ class CommandListener(Cog):
         if ret.strip() != "":
             await ctx.send(ret)
 
-        await self._update_event(event)
+        await update_event(event, self.bot)
         await ctx.send("Event reordered succesfully")
 
     @command(aliases=["roa"])
@@ -506,7 +500,7 @@ class CommandListener(Cog):
             if ret.strip() != "":
                 await ctx.send(ret)
 
-            await self._update_event(event, export=False)
+            await update_event(event, self.bot, export=False)
             await ctx.send(f"Event {event} reordered succesfully")
         await ctx.send("All events reordered succesfully")
         EventDatabase.toJson()
@@ -523,9 +517,9 @@ class CommandListener(Cog):
         except RoleError as e:
             if batch:
                 # Adding the latest role failed, saving previously added roles
-                await self._update_event(event, reorder=False)
+                await update_event(event, self.bot, reorder=False)
             raise e
-        await self._update_event(event, reorder=False, export=(not batch))
+        await update_event(event, self.bot, reorder=False, export=(not batch))
 
     @command(aliases=["ar"])
     async def addrole(self, ctx: Context, event: ArgEvent, *, rolename: UnquotedStr):
@@ -552,12 +546,12 @@ class CommandListener(Cog):
                 msg += "All roles added, updating events\n"
             finally:
                 await ctx.send(msg)
-            await self._update_event(event)
+            await update_event(event, self.bot)
             await ctx.send("Events updated")
         else:
             await self._add_role(event, rolename)
             await ctx.send(f"Role {rolename} added to event {event}")
-        await self._show(ctx, event)
+        await show_event(ctx, event, self.bot)
 
     # Remove additional role from event command
     @command(aliases=["rr"])
@@ -568,9 +562,9 @@ class CommandListener(Cog):
         """
         role_name = role.name
         event.removeAdditionalRole(role)
-        await self._update_event(event, reorder=False)
+        await update_event(event, self.bot, reorder=False)
         await ctx.send(f"Role {role_name} removed from {event}")
-        await self._show(ctx, event)
+        await show_event(ctx, event, self.bot)
 
     @command(aliases=["rnr", "rename"])
     async def renamerole(
@@ -583,11 +577,11 @@ class CommandListener(Cog):
         """
         old_name = role.name
         event.renameAdditionalRole(role, new_name)
-        await self._update_event(event, reorder=False)
+        await update_event(event, self.bot, reorder=False)
         await ctx.send(
             f"Role renamed. Old name: {old_name}, new name: {role} @ {event}"
         )
-        await self._show(ctx, event)
+        await show_event(ctx, event, self.bot)
 
     @command(aliases=["rra"])
     async def removereaction(self, ctx: Context, event: ArgEvent, reaction: str):
@@ -595,9 +589,9 @@ class CommandListener(Cog):
         Removes a role and the corresponding reaction from the event and updates the message.
         """  # NOQA
         self._find_remove_reaction(reaction, event)
-        await self._update_event(event, reorder=False)
+        await update_event(event, self.bot, reorder=False)
         await ctx.send(f"Reaction {reaction} removed from {event}")
-        await self._show(ctx, event)
+        await show_event(ctx, event, self.bot)
 
     def _find_remove_reaction(self, reaction: str, event: Event):
         for group in event.roleGroups.values():
@@ -628,7 +622,7 @@ class CommandListener(Cog):
         await msgFnc.updateMessageEmbed(eventMessage, event)
         EventDatabase.toJson()  # Update JSON file
         await ctx.send(f"Group {groupName} removed from {event}")
-        await self._show(ctx, event)
+        await show_event(ctx, event, self.bot)
 
     # Set title of event command
     @command(aliases=["stt"])
@@ -641,11 +635,11 @@ class CommandListener(Cog):
         # NOTE: Does not check for too long input. Will result in an API error
         # and a bot crash
         event.title = title
-        await self._update_event(event)
+        await update_event(event, self.bot)
         await ctx.send(
             f"Title {event.title} set for operation ID {event.id} at {event.date}"
         )
-        await self._show(ctx, event)
+        await show_event(ctx, event, self.bot)
 
     # Set date of event command
     @command(aliases=["sdt"])
@@ -662,7 +656,7 @@ class CommandListener(Cog):
         await ctx.send(
             f"Date {event.date} set for operation {event.title} ID {event.id}"
         )
-        await self._show(ctx, event)
+        await show_event(ctx, event, self.bot)
 
     # Set time of event command
     @command(aliases=["stm"])
@@ -677,7 +671,7 @@ class CommandListener(Cog):
         # Update event and sort events, export
         await msgFnc.sortEventMessages(self.bot)
         await ctx.send(f"Time set for operation {event}")
-        await self._show(ctx, event)
+        await show_event(ctx, event, self.bot)
 
     # Set terrain of event command
     @command(aliases=["st"])
@@ -688,9 +682,9 @@ class CommandListener(Cog):
         """
         # Change terrain, update event, export
         event.terrain = terrain
-        await self._update_event(event)
+        await update_event(event, self.bot)
         await ctx.send(f"Terrain {event.terrain} set for operation {event}")
-        await self._show(ctx, event)
+        await show_event(ctx, event, self.bot)
 
     # Set faction of event command
     @command(aliases=["sf"])
@@ -701,19 +695,19 @@ class CommandListener(Cog):
         """
         # Change faction, update event, export
         event.faction = faction
-        await self._update_event(event)
+        await update_event(event, self.bot)
         await ctx.send(f"Faction {event.faction} set for operation {event}")
-        await self._show(ctx, event)
+        await show_event(ctx, event, self.bot)
 
     async def _set_description(self, ctx: Context, event: Event, description: str = ""):
         # Change description, update event
         event.description = description
-        await self._update_event(event)
+        await update_event(event, self.bot)
         if description:
             await ctx.send(
                 f'Description "{event.description}" ' f"set for operation {event}"
             )
-            await self._show(ctx, event)
+            await show_event(ctx, event, self.bot)
         else:
             await ctx.send(f"Description cleared from operation {event}")
 
@@ -742,10 +736,10 @@ class CommandListener(Cog):
 
     async def _set_port(self, ctx: Context, event: Event, port: int = cfg.PORT_DEFAULT):
         event.port = port
-        await self._update_event(event)
+        await update_event(event, self.bot)
         if port != cfg.PORT_DEFAULT:
             await ctx.send(f'Port "{event.port}" set for operation {event}')
-            await self._show(ctx, event)
+            await show_event(ctx, event, self.bot)
         else:
             await ctx.send(f"Default port set for operation {event}")
 
@@ -770,11 +764,11 @@ class CommandListener(Cog):
 
     async def _set_mods(self, ctx: Context, event: Event, mods: str = ""):
         event.mods = mods
-        await self._update_event(event)
+        await update_event(event, self.bot)
         if mods:
             await ctx.send(f"Mods ```\n{event.mods}\n``` set for operation {event}")
             await self._set_port(ctx, event, cfg.PORT_MODDED)
-            await self._show(ctx, event)
+            await show_event(ctx, event, self.bot)
         else:
             await ctx.send(f"Mods cleared from operation {event}")
             await self._set_port(ctx, event, cfg.PORT_DEFAULT)
@@ -824,7 +818,7 @@ class CommandListener(Cog):
         msg_zeus = f" with Zeus {zeus.display_name}" if zeus else ""
         if not quiet:
             await ctx.send(f"Updated event {event}{msg_zeus}")
-            await self._show(ctx, event)
+            await show_event(ctx, event, self.bot)
 
     @command(aliases=["sq"])
     async def setquick(
@@ -873,7 +867,7 @@ class CommandListener(Cog):
             role = cast(ArgRole, event.findRoleWithName(cfg.EMOJI_ZEUS))
         # Sign user up, update event, export
         old_signup, replaced_user = event.signup(role, user, replace=True)
-        await self._update_event(event)
+        await update_event(event, self.bot)
         message = f"User {user.display_name} signed up to event {event} as {role.name}"
         if old_signup:
             # User was signed on to a different role previously
@@ -882,7 +876,7 @@ class CommandListener(Cog):
             # Took priority over another user's signup
             message += f". Replaced user {replaced_user.display_name}"
         await ctx.send(message)
-        await self._show(ctx, event)
+        await show_event(ctx, event, self.bot)
 
     # Remove signup on event of user command
     @command(aliases=["rs"])
@@ -902,12 +896,12 @@ class CommandListener(Cog):
             )
             return
 
-        await self._update_event(event)
+        await update_event(event, self.bot)
         await ctx.send(
             f"User {user.display_name} removed from role "
             f"{role.display_name} in event {event}"
         )
-        await self._show(ctx, event)
+        await show_event(ctx, event, self.bot)
 
     # Archive event command
     @command(aliases=["a"])
@@ -1068,7 +1062,7 @@ class CommandListener(Cog):
         if target:
             # Display the loaded event in the command channel
             await msgFnc.createEventMessage(event, target, update_id=False)
-        await self._update_event(event)
+        await update_event(event, self.bot)
 
     # @command()
     # async def createmessages(self, ctx: Context):
@@ -1078,49 +1072,10 @@ class CommandListener(Cog):
     #     EventDatabase.toJson()
     #     await ctx.send("Event messages created")
 
-    async def _update_event(
-        self, event: Event, import_db=False, reorder=True, export=True
-    ) -> bool:
-        """Update event message.
-
-        Creates a new message if missing.
-
-        Args:
-            event (Event): Event to be updated
-            import_db (bool, optional): Import database during update.
-                                        Defaults to False.
-            reorder (bool, optional): Reorder message reactions to match event
-                                      order (delete all and re-add).
-                                      Defaults to True.
-            export (bool, optional): Export database. Defaults to True.
-
-        Returns:
-            bool: Returns True if the message was edited.
-        """
-        # TODO: Move to a more appropriate location
-        if import_db:
-            await self.bot.import_database()
-            # Event instance might have changed because of DB import, get again
-            event = EventDatabase.getEventByMessage(event.messageID)
-
-        changed = False
-        try:
-            message = await msgFnc.getEventMessage(event, self.bot)
-        except MessageNotFound:
-            message = await msgFnc.createEventMessage(event, self.bot.eventchannel)
-            changed = True
-
-        if await msgFnc.updateMessageEmbed(message, event):
-            changed = True
-        await msgFnc.updateReactions(event=event, message=message, reorder=reorder)
-        if export:
-            EventDatabase.toJson()
-        return changed
-
     @command(aliases=["upde"])
     async def updateevent(self, ctx: Context, event: ArgEvent, import_db: bool = False):
         """Import database, update embed and reactions on a single event message."""  # NOQA
-        if await self._update_event(event, import_db=import_db):
+        if await update_event(event, self.bot, import_db=import_db):
             await ctx.send("Event updated")
         else:
             await ctx.send("No changes required")

--- a/src/operationbot/commandListener.py
+++ b/src/operationbot/commandListener.py
@@ -21,7 +21,7 @@ from discord.ext.commands.errors import (
 from operationbot import config as cfg
 from operationbot import messageFunctions as msgFnc
 from operationbot.bot import OperationBot
-from operationbot.command_helpers import show_event, update_event
+from operationbot.command_helpers import set_dlc, show_event, update_event
 from operationbot.converters import (
     ArgArchivedEvent,
     ArgDate,
@@ -795,7 +795,23 @@ class CommandListener(Cog):
 
         Example: clearmods 1
         """
-        await self._set_mods(ctx, event)
+        await self._set_mods(ctx, event, "")
+
+    @command(aliases=["sdlc"])
+    async def setdlc(self, ctx: Context, event: ArgEvent, *, dlc: UnquotedStr):
+        """Set event DLC.
+
+        Example: setdlc 1 APEX
+        """
+        await set_dlc(ctx, event, self.bot, dlc)
+
+    @command(aliases=["cdlc"])
+    async def cleardlc(self, ctx: Context, event: ArgEvent):
+        """Set event DLC.
+
+        Example: cleardlc 1
+        """
+        await set_dlc(ctx, event, self.bot)
 
     async def _set_quick(
         self,

--- a/src/operationbot/command_helpers.py
+++ b/src/operationbot/command_helpers.py
@@ -64,3 +64,21 @@ async def show_event(ctx: Context, event: Event, bot: OperationBot):
     await msgFnc.createEventMessage(
         event, cast(TextChannel, ctx.channel), update_id=False
     )
+
+
+async def set_dlc(ctx: Context, event: Event, bot: OperationBot, dlc: str = ""):
+    """Set a DLC for an event
+
+    Args:
+        ctx (Context): Command context
+        event (Event): Event to modify
+        bot (OperationBot): Main bot instance
+        dlc (str, optional): DLC to set. Defaults to "".
+    """
+    event.dlc = dlc
+    await update_event(event, bot)
+    if dlc:
+        await ctx.send(f"DLC ```\n{event.dlc}\n``` set for operation {event}")
+        await show_event(ctx, event, bot)
+    else:
+        await ctx.send(f"DLC cleared from operation {event}")

--- a/src/operationbot/command_helpers.py
+++ b/src/operationbot/command_helpers.py
@@ -1,0 +1,66 @@
+from typing import cast
+
+from discord.channel import TextChannel
+from discord.ext.commands import Context
+
+from operationbot import messageFunctions as msgFnc
+from operationbot.bot import OperationBot
+from operationbot.errors import MessageNotFound
+from operationbot.event import Event
+from operationbot.eventDatabase import EventDatabase
+
+
+async def update_event(
+    event: Event, bot: OperationBot, import_db=False, reorder=True, export=True
+) -> bool:
+    """Update event message.
+
+    Creates a new message if missing.
+
+    Args:
+        event (Event): Event to be updated
+        bot (OperationBot): The main bot instance
+        import_db (bool, optional): Import database during update.
+                                    Defaults to False.
+        reorder (bool, optional): Reorder message reactions to match event
+                                    order (delete all and re-add).
+                                    Defaults to True.
+        export (bool, optional): Export database. Defaults to True.
+
+    Returns:
+        bool: Returns True if the message was edited.
+    """
+    # TODO: Move to a more appropriate location
+    if import_db:
+        await bot.import_database()
+        # Event instance might have changed because of DB import, get again
+        event = EventDatabase.getEventByMessage(event.messageID)
+
+    changed = False
+    try:
+        message = await msgFnc.getEventMessage(event, bot)
+    except MessageNotFound:
+        message = await msgFnc.createEventMessage(event, bot.eventchannel)
+        changed = True
+
+    if await msgFnc.updateMessageEmbed(message, event):
+        changed = True
+    await msgFnc.updateReactions(event=event, message=message, reorder=reorder)
+    if export:
+        EventDatabase.toJson()
+    return changed
+
+
+async def show_event(ctx: Context, event: Event, bot: OperationBot):
+    """Create a message for a single event
+
+    Args:
+        ctx (Context): Context to send the message to
+        event (Event): Event to show
+        bot (OperationBot): Main bot instance
+    """
+    message = await msgFnc.getEventMessage(event, bot)
+    await ctx.send(f"<{message.jump_url}>")
+    await msgFnc.createEventMessage(
+        event, cast(TextChannel, ctx.channel), update_id=False
+    )

--- a/src/operationbot/event.py
+++ b/src/operationbot/event.py
@@ -52,7 +52,7 @@ class Event:
     ):
         self._title: str | None = None
         self.date = date
-        self._terrain = TERRAIN
+        self.terrain = TERRAIN
         self.faction = FACTION
         self.description = DESCRIPTION
         self.port = cfg.PORT_DEFAULT
@@ -62,7 +62,7 @@ class Event:
         self.id = eventID
         self.sideop = sideop
         self.attendees: list[User | discord.abc.User] = []
-        self.dlc: str | None = None
+        self._dlc: str = ""
         self.embed_hash = ""
 
         if platoon_size is None:
@@ -409,16 +409,16 @@ class Event:
         self.date = self.date.replace(hour=time.hour, minute=time.minute)
 
     @property
-    def terrain(self) -> str:
-        return self._terrain
+    def dlc(self) -> str:
+        if self._dlc:
+            return self._dlc
+        if self.terrain in cfg.DLC_TERRAINS:
+            return cfg.DLC_TERRAINS[self.terrain]
+        return ""
 
-    @terrain.setter
-    def terrain(self, terrain):
-        if terrain in cfg.DLC_TERRAINS:
-            self.dlc = cfg.DLC_TERRAINS[terrain]
-        else:
-            self.dlc = None
-        self._terrain = terrain
+    @dlc.setter
+    def dlc(self, dlc):
+        self._dlc = dlc
 
     # Get emojis for normal roles
     def _getNormalEmojis(self, guildEmojis: tuple[Emoji, ...]) -> dict[str, Emoji]:
@@ -585,6 +585,7 @@ class Event:
         data["faction"] = self.faction
         data["port"] = self.port
         data["mods"] = self.mods
+        data["dlc"] = self._dlc
         if not brief_output:
             data["messageID"] = self.messageID
             data["platoon_size"] = self.platoon_size
@@ -603,6 +604,7 @@ class Event:
         self.port = int(data.get("port", cfg.PORT_DEFAULT))
         self.description = str(data.get("description", DESCRIPTION))
         self.mods = str(data.get("mods", MODS))
+        self.dlc = data.get("dlc", "")
         if not manual_load:
             self.messageID = int(data.get("messageID", 0))
             self.platoon_size = str(data.get("platoon_size", PLATOON_SIZE))

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,9 +1,6 @@
-from datetime import datetime, time, timedelta, timezone
-from typing import cast
+from datetime import datetime, timedelta, timezone
 
-from discord import Embed
 from operationbot import config as cfg
-from operationbot.event import Event
 from operationbot.eventDatabase import EventDatabase as db
 
 
@@ -55,55 +52,3 @@ def test_archive_past_delta():
     assert len(db.eventsArchive) == 0
     assert db.events.get(0) == event_past
     assert db.events.get(1) == event_coming
-
-
-def test_default():
-    date = datetime(2020, 1, 1, 12, 0, 0)
-    event = Event(date, (), platoon_size="empty")
-
-    assert event.date == date
-    assert event.time == time(hour=date.hour, minute=date.minute)
-    date = datetime(2020, 1, 2, 12, 0, 0)
-    event.date = date
-    assert event.date == date
-
-    event.faction = "USMC"
-    assert event.faction == "USMC"
-
-    event.terrain = "Stratis"
-    assert event.terrain == "Stratis"
-
-    assert event.title == "Operation"
-    assert event.description == ""
-    timestamp = _timestamp(date)
-    # A non-cached embed will never be None, casting to make the linters happy
-    embed = cast(Embed, event.createEmbed(cache=False))
-    assert embed.description == (
-        f"Local time: <t:{timestamp}> "
-        f"(<t:{timestamp}:R>)"
-        f"\nTerrain: Stratis - Faction: USMC"
-    )
-
-
-def test_dlc():
-    date = datetime(2020, 1, 1, 12, 0, 0)
-    event = Event(date, (), platoon_size="empty")
-
-    event.terrain = "Tanoa"
-    assert event.terrain == "Tanoa"
-    assert event.faction == "unknown"
-    assert event.title == "APEX Operation"
-    assert event.description == ""
-    timestamp = _timestamp(date)
-    # A non-cached embed will never be None, casting to make the linters happy
-    embed = cast(Embed, event.createEmbed(cache=False))
-    assert embed.description == (
-        f"Local time: <t:{timestamp}> "
-        f"(<t:{timestamp}:R>)"
-        f"\nTerrain: {event.terrain} - Faction: {event.faction}\n\n"
-        f"The **{event.dlc} DLC** is required to join this event"
-    )
-    event.terrain = "Stratis"
-    assert event.dlc is None
-    event.dlc = "GlobMob"
-    assert event.dlc == "GlobMob"

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -12,7 +12,7 @@ def _timestamp(date: datetime) -> int:
 
 def test_default():
     date = datetime(2020, 1, 1, 12, 0, 0)
-    event = Event(date, (), platoon_size="empty")
+    event = Event(date, guildEmojis=(), platoon_size="empty")
 
     assert event.date == date
     assert event.time == time(hour=date.hour, minute=date.minute)
@@ -40,7 +40,7 @@ def test_default():
 
 def test_dlc():
     date = datetime(2020, 1, 1, 12, 0, 0)
-    event = Event(date, (), platoon_size="empty")
+    event = Event(date, guildEmojis=(), platoon_size="empty")
 
     event.terrain = "Tanoa"
     assert event.terrain == "Tanoa"
@@ -57,6 +57,15 @@ def test_dlc():
         f"The **{event.dlc} DLC** is required to join this event"
     )
     event.terrain = "Stratis"
-    assert event.dlc is None
+    assert event.dlc == ""
     event.dlc = "GlobMob"
     assert event.dlc == "GlobMob"
+
+
+def test_manual_dlc():
+    date = datetime(2020, 1, 1, 12, 0, 0)
+    event = Event(date, guildEmojis=(), platoon_size="empty")
+    event.dlc = "APEX"
+    event.terrain = "Stratis"
+    assert event.dlc == "APEX"
+    assert event.terrain == "Stratis"


### PR DESCRIPTION
These commands allow setting and clearing an event DLC, respectively

- **Relax python version requirement**
- **Remove duplicate tests**
- **Move command helper functions to a separate module**
- **Add support for setting DLC manually on an event**
- **Add !sdlc, !cdlc commands**
